### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/bindings/python/llvm/bit_reader.py
+++ b/bindings/python/llvm/bit_reader.py
@@ -19,7 +19,7 @@ def parse_bitcode(mem_buffer):
     out = c_char_p(None)
     result = lib.LLVMParseBitcode(mem_buffer, byref(module), byref(out))
     if result:
-        raise RuntimeError('LLVM Error: %s' % out.value)
+        raise RuntimeError('LLVM Error: {0!s}'.format(out.value))
     m = Module(module)
     m.take_ownership(mem_buffer)
     return m

--- a/bindings/python/llvm/core.py
+++ b/bindings/python/llvm/core.py
@@ -43,7 +43,7 @@ class LLVMEnumeration(object):
         self.value = value
 
     def __repr__(self):
-        return '%s.%s' % (self.__class__.__name__,
+        return '{0!s}.{1!s}'.format(self.__class__.__name__,
                           self.name)
 
     @classmethod
@@ -52,7 +52,7 @@ class LLVMEnumeration(object):
         result = cls._value_map.get(value, None)
 
         if result is None:
-            raise ValueError('Unknown %s: %d' % (cls.__name__,
+            raise ValueError('Unknown {0!s}: {1:d}'.format(cls.__name__,
                                                  value))
 
         return result
@@ -65,7 +65,7 @@ class LLVMEnumeration(object):
         enumerations. You should not need to call this outside this module.
         """
         if value in cls._value_map:
-            raise ValueError('%s value already registered: %d' % (cls.__name__,
+            raise ValueError('{0!s} value already registered: {1:d}'.format(cls.__name__,
                                                                   value))
         enum = cls(name, value)
         cls._value_map[value] = enum
@@ -162,7 +162,7 @@ class MemoryBuffer(LLVMObject):
                 byref(memory), byref(out))
 
         if result:
-            raise Exception("Could not create memory buffer: %s" % out.value)
+            raise Exception("Could not create memory buffer: {0!s}".format(out.value))
 
         LLVMObject.__init__(self, memory, disposer=lib.LLVMDisposeMemoryBuffer)
 
@@ -264,7 +264,7 @@ class Module(LLVMObject):
         # Result is inverted so 0 means everything was ok.
         result = lib.LLVMPrintModuleToFile(self, filename, byref(out))        
         if result:
-            raise RuntimeError("LLVM Error: %s" % out.value)
+            raise RuntimeError("LLVM Error: {0!s}".format(out.value))
 
 class Function(Value):
 

--- a/bindings/python/llvm/disassembler.py
+++ b/bindings/python/llvm/disassembler.py
@@ -76,8 +76,8 @@ class Disassembler(LLVMObject):
         ptr = lib.LLVMCreateDisasm(c_char_p(triple), c_void_p(None), c_int(0),
                 callbacks['op_info'](0), callbacks['symbol_lookup'](0))
         if not ptr:
-            raise Exception('Could not obtain disassembler for triple: %s' %
-                            triple)
+            raise Exception('Could not obtain disassembler for triple: {0!s}'.format(
+                            triple))
 
         LLVMObject.__init__(self, ptr, disposer=lib.LLVMDisasmDispose)
 
@@ -143,7 +143,7 @@ class Disassembler(LLVMObject):
 
     def set_options(self, options):
         if not lib.LLVMSetDisasmOptions(self, options):
-            raise Exception('Unable to set all disassembler options in %i' % options)
+            raise Exception('Unable to set all disassembler options in {0:d}'.format(options))
 
 
 def register_library(library):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'LLVM'
-copyright = u'2003-%d, LLVM Project' % date.today().year
+copyright = u'2003-{0:d}, LLVM Project'.format(date.today().year)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -233,8 +233,8 @@ for name in os.listdir(command_guide_path):
 
         if len(header) != len(title):
             print >>sys.stderr, (
-                "error: invalid header in %r (does not match title)" % (
-                    file_subpath,))
+                "error: invalid header in {0!r} (does not match title)".format(
+                    file_subpath))
         if ' - ' not in title:
             print >>sys.stderr, (
                 ("error: invalid title in %r "

--- a/examples/Kaleidoscope/MCJIT/cached/genk-timing.py
+++ b/examples/Kaleidoscope/MCJIT/cached/genk-timing.py
@@ -8,26 +8,26 @@ class TimingScriptGenerator:
     def __init__(self, scriptname, outputname):
         self.timeFile = outputname
         self.shfile = open(scriptname, 'w')
-        self.shfile.write("echo \"\" > %s\n" % self.timeFile)
+        self.shfile.write("echo \"\" > {0!s}\n".format(self.timeFile))
 
     def writeTimingCall(self, filename, numFuncs, funcsCalled, totalCalls):
         """Echo some comments and invoke both versions of toy"""
         rootname = filename
         if '.' in filename:
             rootname = filename[:filename.rfind('.')]
-        self.shfile.write("echo \"%s: Calls %d of %d functions, %d total\" >> %s\n" % (filename, funcsCalled, numFuncs, totalCalls, self.timeFile))
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
-        self.shfile.write("echo \"With MCJIT\" >> %s\n" % self.timeFile)
+        self.shfile.write("echo \"{0!s}: Calls {1:d} of {2:d} functions, {3:d} total\" >> {4!s}\n".format(filename, funcsCalled, numFuncs, totalCalls, self.timeFile))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
+        self.shfile.write("echo \"With MCJIT\" >> {0!s}\n".format(self.timeFile))
         self.shfile.write("/usr/bin/time -f \"Command %C\\n\\tuser time: %U s\\n\\tsytem time: %S s\\n\\tmax set: %M kb\"")
-        self.shfile.write(" -o %s -a " % self.timeFile)
-        self.shfile.write("./toy-mcjit < %s > %s-mcjit.out 2> %s-mcjit.err\n" % (filename, rootname, rootname))
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
-        self.shfile.write("echo \"With JIT\" >> %s\n" % self.timeFile)
+        self.shfile.write(" -o {0!s} -a ".format(self.timeFile))
+        self.shfile.write("./toy-mcjit < {0!s} > {1!s}-mcjit.out 2> {2!s}-mcjit.err\n".format(filename, rootname, rootname))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
+        self.shfile.write("echo \"With JIT\" >> {0!s}\n".format(self.timeFile))
         self.shfile.write("/usr/bin/time -f \"Command %C\\n\\tuser time: %U s\\n\\tsytem time: %S s\\n\\tmax set: %M kb\"")
-        self.shfile.write(" -o %s -a " % self.timeFile)
-        self.shfile.write("./toy-jit < %s > %s-jit.out 2> %s-jit.err\n" % (filename, rootname, rootname))
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
+        self.shfile.write(" -o {0!s} -a ".format(self.timeFile))
+        self.shfile.write("./toy-jit < {0!s} > {1!s}-jit.out 2> {2!s}-jit.err\n".format(filename, rootname, rootname))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
 
 class KScriptGenerator:
     """Used to generate random Kaleidoscope code"""
@@ -116,21 +116,21 @@ class KScriptGenerator:
         if shouldCallFunc:
             funcToCall = random.randrange(1, self.lastFuncNum - 1)
             self.updateFunctionCallMap(self.lastFuncNum, funcToCall)
-            self.writeln("  %s = func%d(%s, %s) :" % (LValue, funcToCall, LHS, RHS))
+            self.writeln("  {0!s} = func{1:d}({2!s}, {3!s}) :".format(LValue, funcToCall, LHS, RHS))
         else:
             possibleOperations = ["+", "-", "*", "/"]
             operation = random.choice(possibleOperations)
             if operation == "-":
                 # Don't let our intermediate value become zero
                 # This is complicated by the fact that '<' is our only comparison operator
-                self.writeln("  if %s < %s then" % (LHS, RHS))
-                self.writeln("    %s = %s %s %s" % (LValue, LHS, operation, RHS))
-                self.writeln("  else if %s < %s then" % (RHS, LHS))
-                self.writeln("    %s = %s %s %s" % (LValue, LHS, operation, RHS))
+                self.writeln("  if {0!s} < {1!s} then".format(LHS, RHS))
+                self.writeln("    {0!s} = {1!s} {2!s} {3!s}".format(LValue, LHS, operation, RHS))
+                self.writeln("  else if {0!s} < {1!s} then".format(RHS, LHS))
+                self.writeln("    {0!s} = {1!s} {2!s} {3!s}".format(LValue, LHS, operation, RHS))
                 self.writeln("  else")
-                self.writeln("    %s = %s %s %f :" % (LValue, LHS, operation, random.uniform(1, 100)))
+                self.writeln("    {0!s} = {1!s} {2!s} {3:f} :".format(LValue, LHS, operation, random.uniform(1, 100)))
             else:
-                self.writeln("  %s = %s %s %s :" % (LValue, LHS, operation, RHS))
+                self.writeln("  {0!s} = {1!s} {2!s} {3!s} :".format(LValue, LHS, operation, RHS))
 
     def getNextFuncNum(self):
         result = self.nextFuncNum
@@ -140,8 +140,8 @@ class KScriptGenerator:
 
     def writeFunction(self, elements):
         funcNum = self.getNextFuncNum()
-        self.writeComment("Auto-generated function number %d" % funcNum)
-        self.writeln("def func%d(X Y)" % funcNum)
+        self.writeComment("Auto-generated function number {0:d}".format(funcNum))
+        self.writeln("def func{0:d}(X Y)".format(funcNum))
         self.writeln("  var temp1 = X,")
         self.writeln("      temp2 = Y,")
         self.writeln("      temp3 in")
@@ -164,26 +164,24 @@ class KScriptGenerator:
         self.writeComment("Call the last function")
         arg1 = random.uniform(1, 100)
         arg2 = random.uniform(1, 100)
-        self.writeln("printresult(%d, func%d(%f, %f) )" % (self.lastFuncNum, self.lastFuncNum, arg1, arg2))
+        self.writeln("printresult({0:d}, func{1:d}({2:f}, {3:f}) )".format(self.lastFuncNum, self.lastFuncNum, arg1, arg2))
         self.writeEmptyLine()
         self.updateCalledFunctionList(self.lastFuncNum)
 
     def writeFinalFunctionCounts(self):
-        self.writeComment("Called %d of %d functions" % (len(self.calledFunctions), self.lastFuncNum))
+        self.writeComment("Called {0:d} of {1:d} functions".format(len(self.calledFunctions), self.lastFuncNum))
 
 def generateKScript(filename, numFuncs, elementsPerFunc, funcsBetweenExec, callWeighting, timingScript):
     """ Generate a random Kaleidoscope script based on the given parameters """
     print "Generating " + filename
-    print("  %d functions, %d elements per function, %d functions between execution" %
-          (numFuncs, elementsPerFunc, funcsBetweenExec))
-    print("  Call weighting = %f" % callWeighting)
+    print("  {0:d} functions, {1:d} elements per function, {2:d} functions between execution".format(numFuncs, elementsPerFunc, funcsBetweenExec))
+    print("  Call weighting = {0:f}".format(callWeighting))
     script = KScriptGenerator(filename)
     script.setCallWeighting(callWeighting)
     script.writeComment("===========================================================================")
     script.writeComment("Auto-generated script")
-    script.writeComment("  %d functions, %d elements per function, %d functions between execution"
-                         % (numFuncs, elementsPerFunc, funcsBetweenExec))
-    script.writeComment("  call weighting = %f" % callWeighting)
+    script.writeComment("  {0:d} functions, {1:d} elements per function, {2:d} functions between execution".format(numFuncs, elementsPerFunc, funcsBetweenExec))
+    script.writeComment("  call weighting = {0:f}".format(callWeighting))
     script.writeComment("===========================================================================")
     script.writeEmptyLine()
     script.writePredefinedFunctions()
@@ -200,7 +198,7 @@ def generateKScript(filename, numFuncs, elementsPerFunc, funcsBetweenExec, callW
     script.writeEmptyLine()
     script.writeFinalFunctionCounts()
     funcsCalled = len(script.calledFunctions)
-    print "  Called %d of %d functions, %d total" % (funcsCalled, numFuncs, script.totalCallsExecuted)
+    print "  Called {0:d} of {1:d} functions, {2:d} total".format(funcsCalled, numFuncs, script.totalCallsExecuted)
     timingScript.writeTimingCall(filename, numFuncs, funcsCalled, script.totalCallsExecuted)
 
 # Execution begins here
@@ -214,6 +212,6 @@ dataSets = [(5000, 3,  50, 0.50), (5000, 10, 100, 0.10), (5000, 10, 5, 0.10), (5
 
 # Generate the code
 for (numFuncs, elementsPerFunc, funcsBetweenExec, callWeighting) in dataSets:
-    filename = "test-%d-%d-%d-%d.k" % (numFuncs, elementsPerFunc, funcsBetweenExec, int(callWeighting * 100))
+    filename = "test-{0:d}-{1:d}-{2:d}-{3:d}.k".format(numFuncs, elementsPerFunc, funcsBetweenExec, int(callWeighting * 100))
     generateKScript(filename, numFuncs, elementsPerFunc, funcsBetweenExec, callWeighting, timingScript)
 print "All done!"

--- a/examples/Kaleidoscope/MCJIT/cached/split-lib.py
+++ b/examples/Kaleidoscope/MCJIT/cached/split-lib.py
@@ -5,31 +5,31 @@ class TimingScriptGenerator:
     def __init__(self, scriptname, outputname):
         self.shfile = open(scriptname, 'w')
         self.timeFile = outputname
-        self.shfile.write("echo \"\" > %s\n" % self.timeFile)
+        self.shfile.write("echo \"\" > {0!s}\n".format(self.timeFile))
 
     def writeTimingCall(self, irname, callname):
         """Echo some comments and invoke both versions of toy"""
         rootname = irname
         if '.' in irname:
             rootname = irname[:irname.rfind('.')]
-        self.shfile.write("echo \"%s: Calls %s\" >> %s\n" % (callname, irname, self.timeFile))
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
-        self.shfile.write("echo \"With MCJIT\" >> %s\n" % self.timeFile)
+        self.shfile.write("echo \"{0!s}: Calls {1!s}\" >> {2!s}\n".format(callname, irname, self.timeFile))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
+        self.shfile.write("echo \"With MCJIT\" >> {0!s}\n".format(self.timeFile))
         self.shfile.write("/usr/bin/time -f \"Command %C\\n\\tuser time: %U s\\n\\tsytem time: %S s\\n\\tmax set: %M kb\"")
-        self.shfile.write(" -o %s -a " % self.timeFile)
-        self.shfile.write("./toy-mcjit -use-object-cache -input-IR=%s < %s > %s-mcjit.out 2> %s-mcjit.err\n" % (irname, callname, rootname, rootname))
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
-        self.shfile.write("echo \"With MCJIT again\" >> %s\n" % self.timeFile)
+        self.shfile.write(" -o {0!s} -a ".format(self.timeFile))
+        self.shfile.write("./toy-mcjit -use-object-cache -input-IR={0!s} < {1!s} > {2!s}-mcjit.out 2> {3!s}-mcjit.err\n".format(irname, callname, rootname, rootname))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
+        self.shfile.write("echo \"With MCJIT again\" >> {0!s}\n".format(self.timeFile))
         self.shfile.write("/usr/bin/time -f \"Command %C\\n\\tuser time: %U s\\n\\tsytem time: %S s\\n\\tmax set: %M kb\"")
-        self.shfile.write(" -o %s -a " % self.timeFile)
-        self.shfile.write("./toy-mcjit -use-object-cache -input-IR=%s < %s > %s-mcjit.out 2> %s-mcjit.err\n" % (irname, callname, rootname, rootname))
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
-        self.shfile.write("echo \"With JIT\" >> %s\n" % self.timeFile)
+        self.shfile.write(" -o {0!s} -a ".format(self.timeFile))
+        self.shfile.write("./toy-mcjit -use-object-cache -input-IR={0!s} < {1!s} > {2!s}-mcjit.out 2> {3!s}-mcjit.err\n".format(irname, callname, rootname, rootname))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
+        self.shfile.write("echo \"With JIT\" >> {0!s}\n".format(self.timeFile))
         self.shfile.write("/usr/bin/time -f \"Command %C\\n\\tuser time: %U s\\n\\tsytem time: %S s\\n\\tmax set: %M kb\"")
-        self.shfile.write(" -o %s -a " % self.timeFile)
-        self.shfile.write("./toy-jit -input-IR=%s < %s > %s-mcjit.out 2> %s-mcjit.err\n" % (irname, callname, rootname, rootname))
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
+        self.shfile.write(" -o {0!s} -a ".format(self.timeFile))
+        self.shfile.write("./toy-jit -input-IR={0!s} < {1!s} > {2!s}-mcjit.out 2> {3!s}-mcjit.err\n".format(irname, callname, rootname, rootname))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
 
 class LibScriptGenerator:
     """Used to generate a bash script which will convert Kaleidoscope files to IR"""
@@ -37,7 +37,7 @@ class LibScriptGenerator:
         self.shfile = open(filename, 'w')
 
     def writeLibGenCall(self, libname, irname):
-        self.shfile.write("./toy-ir-gen < %s 2> %s\n" % (libname, irname))
+        self.shfile.write("./toy-ir-gen < {0!s} 2> {1!s}\n".format(libname, irname))
 
 def splitScript(inputname, libGenScript, timingScript):
   rootname = inputname[:-2]
@@ -47,7 +47,7 @@ def splitScript(inputname, libGenScript, timingScript):
   infile = open(inputname, "r")
   libfile = open(libname, "w")
   callfile = open(callname, "w")
-  print "Splitting %s into %s and %s" % (inputname, callname, libname)
+  print "Splitting {0!s} into {1!s} and {2!s}".format(inputname, callname, libname)
   for line in infile:
     if not line.startswith("#"):
       if line.startswith("print"):

--- a/examples/Kaleidoscope/MCJIT/complete/genk-timing.py
+++ b/examples/Kaleidoscope/MCJIT/complete/genk-timing.py
@@ -8,31 +8,31 @@ class TimingScriptGenerator:
     def __init__(self, scriptname, outputname):
         self.timeFile = outputname
         self.shfile = open(scriptname, 'w')
-        self.shfile.write("echo \"\" > %s\n" % self.timeFile)
+        self.shfile.write("echo \"\" > {0!s}\n".format(self.timeFile))
 
     def writeTimingCall(self, filename, numFuncs, funcsCalled, totalCalls):
         """Echo some comments and invoke both versions of toy"""
         rootname = filename
         if '.' in filename:
             rootname = filename[:filename.rfind('.')]
-        self.shfile.write("echo \"%s: Calls %d of %d functions, %d total\" >> %s\n" % (filename, funcsCalled, numFuncs, totalCalls, self.timeFile))
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
-        self.shfile.write("echo \"With MCJIT (original)\" >> %s\n" % self.timeFile)
+        self.shfile.write("echo \"{0!s}: Calls {1:d} of {2:d} functions, {3:d} total\" >> {4!s}\n".format(filename, funcsCalled, numFuncs, totalCalls, self.timeFile))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
+        self.shfile.write("echo \"With MCJIT (original)\" >> {0!s}\n".format(self.timeFile))
         self.shfile.write("/usr/bin/time -f \"Command %C\\n\\tuser time: %U s\\n\\tsytem time: %S s\\n\\tmax set: %M kb\"")
-        self.shfile.write(" -o %s -a " % self.timeFile)
-        self.shfile.write("./toy -suppress-prompts -use-mcjit=true -enable-lazy-compilation=false < %s > %s-mcjit.out 2> %s-mcjit.err\n" % (filename, rootname, rootname))
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
-        self.shfile.write("echo \"With MCJIT (lazy)\" >> %s\n" % self.timeFile)
+        self.shfile.write(" -o {0!s} -a ".format(self.timeFile))
+        self.shfile.write("./toy -suppress-prompts -use-mcjit=true -enable-lazy-compilation=false < {0!s} > {1!s}-mcjit.out 2> {2!s}-mcjit.err\n".format(filename, rootname, rootname))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
+        self.shfile.write("echo \"With MCJIT (lazy)\" >> {0!s}\n".format(self.timeFile))
         self.shfile.write("/usr/bin/time -f \"Command %C\\n\\tuser time: %U s\\n\\tsytem time: %S s\\n\\tmax set: %M kb\"")
-        self.shfile.write(" -o %s -a " % self.timeFile)
-        self.shfile.write("./toy -suppress-prompts -use-mcjit=true -enable-lazy-compilation=true < %s > %s-mcjit-lazy.out 2> %s-mcjit-lazy.err\n" % (filename, rootname, rootname))
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
-        self.shfile.write("echo \"With JIT\" >> %s\n" % self.timeFile)
+        self.shfile.write(" -o {0!s} -a ".format(self.timeFile))
+        self.shfile.write("./toy -suppress-prompts -use-mcjit=true -enable-lazy-compilation=true < {0!s} > {1!s}-mcjit-lazy.out 2> {2!s}-mcjit-lazy.err\n".format(filename, rootname, rootname))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
+        self.shfile.write("echo \"With JIT\" >> {0!s}\n".format(self.timeFile))
         self.shfile.write("/usr/bin/time -f \"Command %C\\n\\tuser time: %U s\\n\\tsytem time: %S s\\n\\tmax set: %M kb\"")
-        self.shfile.write(" -o %s -a " % self.timeFile)
-        self.shfile.write("./toy -suppress-prompts -use-mcjit=false < %s > %s-jit.out 2> %s-jit.err\n" % (filename, rootname, rootname))
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
+        self.shfile.write(" -o {0!s} -a ".format(self.timeFile))
+        self.shfile.write("./toy -suppress-prompts -use-mcjit=false < {0!s} > {1!s}-jit.out 2> {2!s}-jit.err\n".format(filename, rootname, rootname))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
 
 class KScriptGenerator:
     """Used to generate random Kaleidoscope code"""
@@ -121,21 +121,21 @@ class KScriptGenerator:
         if shouldCallFunc:
             funcToCall = random.randrange(1, self.lastFuncNum - 1)
             self.updateFunctionCallMap(self.lastFuncNum, funcToCall)
-            self.writeln("  %s = func%d(%s, %s) :" % (LValue, funcToCall, LHS, RHS))
+            self.writeln("  {0!s} = func{1:d}({2!s}, {3!s}) :".format(LValue, funcToCall, LHS, RHS))
         else:
             possibleOperations = ["+", "-", "*", "/"]
             operation = random.choice(possibleOperations)
             if operation == "-":
                 # Don't let our intermediate value become zero
                 # This is complicated by the fact that '<' is our only comparison operator
-                self.writeln("  if %s < %s then" % (LHS, RHS))
-                self.writeln("    %s = %s %s %s" % (LValue, LHS, operation, RHS))
-                self.writeln("  else if %s < %s then" % (RHS, LHS))
-                self.writeln("    %s = %s %s %s" % (LValue, LHS, operation, RHS))
+                self.writeln("  if {0!s} < {1!s} then".format(LHS, RHS))
+                self.writeln("    {0!s} = {1!s} {2!s} {3!s}".format(LValue, LHS, operation, RHS))
+                self.writeln("  else if {0!s} < {1!s} then".format(RHS, LHS))
+                self.writeln("    {0!s} = {1!s} {2!s} {3!s}".format(LValue, LHS, operation, RHS))
                 self.writeln("  else")
-                self.writeln("    %s = %s %s %f :" % (LValue, LHS, operation, random.uniform(1, 100)))
+                self.writeln("    {0!s} = {1!s} {2!s} {3:f} :".format(LValue, LHS, operation, random.uniform(1, 100)))
             else:
-                self.writeln("  %s = %s %s %s :" % (LValue, LHS, operation, RHS))
+                self.writeln("  {0!s} = {1!s} {2!s} {3!s} :".format(LValue, LHS, operation, RHS))
 
     def getNextFuncNum(self):
         result = self.nextFuncNum
@@ -145,8 +145,8 @@ class KScriptGenerator:
 
     def writeFunction(self, elements):
         funcNum = self.getNextFuncNum()
-        self.writeComment("Auto-generated function number %d" % funcNum)
-        self.writeln("def func%d(X Y)" % funcNum)
+        self.writeComment("Auto-generated function number {0:d}".format(funcNum))
+        self.writeln("def func{0:d}(X Y)".format(funcNum))
         self.writeln("  var temp1 = X,")
         self.writeln("      temp2 = Y,")
         self.writeln("      temp3 in")
@@ -169,26 +169,24 @@ class KScriptGenerator:
         self.writeComment("Call the last function")
         arg1 = random.uniform(1, 100)
         arg2 = random.uniform(1, 100)
-        self.writeln("printresult(%d, func%d(%f, %f) )" % (self.lastFuncNum, self.lastFuncNum, arg1, arg2))
+        self.writeln("printresult({0:d}, func{1:d}({2:f}, {3:f}) )".format(self.lastFuncNum, self.lastFuncNum, arg1, arg2))
         self.writeEmptyLine()
         self.updateCalledFunctionList(self.lastFuncNum)
 
     def writeFinalFunctionCounts(self):
-        self.writeComment("Called %d of %d functions" % (len(self.calledFunctions), self.lastFuncNum))
+        self.writeComment("Called {0:d} of {1:d} functions".format(len(self.calledFunctions), self.lastFuncNum))
 
 def generateKScript(filename, numFuncs, elementsPerFunc, funcsBetweenExec, callWeighting, timingScript):
     """ Generate a random Kaleidoscope script based on the given parameters """
     print "Generating " + filename
-    print("  %d functions, %d elements per function, %d functions between execution" %
-          (numFuncs, elementsPerFunc, funcsBetweenExec))
-    print("  Call weighting = %f" % callWeighting)
+    print("  {0:d} functions, {1:d} elements per function, {2:d} functions between execution".format(numFuncs, elementsPerFunc, funcsBetweenExec))
+    print("  Call weighting = {0:f}".format(callWeighting))
     script = KScriptGenerator(filename)
     script.setCallWeighting(callWeighting)
     script.writeComment("===========================================================================")
     script.writeComment("Auto-generated script")
-    script.writeComment("  %d functions, %d elements per function, %d functions between execution"
-                         % (numFuncs, elementsPerFunc, funcsBetweenExec))
-    script.writeComment("  call weighting = %f" % callWeighting)
+    script.writeComment("  {0:d} functions, {1:d} elements per function, {2:d} functions between execution".format(numFuncs, elementsPerFunc, funcsBetweenExec))
+    script.writeComment("  call weighting = {0:f}".format(callWeighting))
     script.writeComment("===========================================================================")
     script.writeEmptyLine()
     script.writePredefinedFunctions()
@@ -205,7 +203,7 @@ def generateKScript(filename, numFuncs, elementsPerFunc, funcsBetweenExec, callW
     script.writeEmptyLine()
     script.writeFinalFunctionCounts()
     funcsCalled = len(script.calledFunctions)
-    print "  Called %d of %d functions, %d total" % (funcsCalled, numFuncs, script.totalCallsExecuted)
+    print "  Called {0:d} of {1:d} functions, {2:d} total".format(funcsCalled, numFuncs, script.totalCallsExecuted)
     timingScript.writeTimingCall(filename, numFuncs, funcsCalled, script.totalCallsExecuted)
 
 # Execution begins here
@@ -219,6 +217,6 @@ dataSets = [(5000, 3,  50, 0.50), (5000, 10, 100, 0.10), (5000, 10, 5, 0.10), (5
 
 # Generate the code
 for (numFuncs, elementsPerFunc, funcsBetweenExec, callWeighting) in dataSets:
-    filename = "test-%d-%d-%d-%d.k" % (numFuncs, elementsPerFunc, funcsBetweenExec, int(callWeighting * 100))
+    filename = "test-{0:d}-{1:d}-{2:d}-{3:d}.k".format(numFuncs, elementsPerFunc, funcsBetweenExec, int(callWeighting * 100))
     generateKScript(filename, numFuncs, elementsPerFunc, funcsBetweenExec, callWeighting, timingScript)
 print "All done!"

--- a/examples/Kaleidoscope/MCJIT/complete/split-lib.py
+++ b/examples/Kaleidoscope/MCJIT/complete/split-lib.py
@@ -5,31 +5,31 @@ class TimingScriptGenerator:
     def __init__(self, scriptname, outputname):
         self.shfile = open(scriptname, 'w')
         self.timeFile = outputname
-        self.shfile.write("echo \"\" > %s\n" % self.timeFile)
+        self.shfile.write("echo \"\" > {0!s}\n".format(self.timeFile))
 
     def writeTimingCall(self, irname, callname):
         """Echo some comments and invoke both versions of toy"""
         rootname = irname
         if '.' in irname:
             rootname = irname[:irname.rfind('.')]
-        self.shfile.write("echo \"%s: Calls %s\" >> %s\n" % (callname, irname, self.timeFile))
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
-        self.shfile.write("echo \"With MCJIT\" >> %s\n" % self.timeFile)
+        self.shfile.write("echo \"{0!s}: Calls {1!s}\" >> {2!s}\n".format(callname, irname, self.timeFile))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
+        self.shfile.write("echo \"With MCJIT\" >> {0!s}\n".format(self.timeFile))
         self.shfile.write("/usr/bin/time -f \"Command %C\\n\\tuser time: %U s\\n\\tsytem time: %S s\\n\\tmax set: %M kb\"")
-        self.shfile.write(" -o %s -a " % self.timeFile)
-        self.shfile.write("./toy -suppress-prompts -use-mcjit=true -enable-lazy-compilation=true -use-object-cache -input-IR=%s < %s > %s-mcjit.out 2> %s-mcjit.err\n" % (irname, callname, rootname, rootname))
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
-        self.shfile.write("echo \"With MCJIT again\" >> %s\n" % self.timeFile)
+        self.shfile.write(" -o {0!s} -a ".format(self.timeFile))
+        self.shfile.write("./toy -suppress-prompts -use-mcjit=true -enable-lazy-compilation=true -use-object-cache -input-IR={0!s} < {1!s} > {2!s}-mcjit.out 2> {3!s}-mcjit.err\n".format(irname, callname, rootname, rootname))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
+        self.shfile.write("echo \"With MCJIT again\" >> {0!s}\n".format(self.timeFile))
         self.shfile.write("/usr/bin/time -f \"Command %C\\n\\tuser time: %U s\\n\\tsytem time: %S s\\n\\tmax set: %M kb\"")
-        self.shfile.write(" -o %s -a " % self.timeFile)
-        self.shfile.write("./toy -suppress-prompts -use-mcjit=true -enable-lazy-compilation=true -use-object-cache -input-IR=%s < %s > %s-mcjit.out 2> %s-mcjit.err\n" % (irname, callname, rootname, rootname))
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
-        self.shfile.write("echo \"With JIT\" >> %s\n" % self.timeFile)
+        self.shfile.write(" -o {0!s} -a ".format(self.timeFile))
+        self.shfile.write("./toy -suppress-prompts -use-mcjit=true -enable-lazy-compilation=true -use-object-cache -input-IR={0!s} < {1!s} > {2!s}-mcjit.out 2> {3!s}-mcjit.err\n".format(irname, callname, rootname, rootname))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
+        self.shfile.write("echo \"With JIT\" >> {0!s}\n".format(self.timeFile))
         self.shfile.write("/usr/bin/time -f \"Command %C\\n\\tuser time: %U s\\n\\tsytem time: %S s\\n\\tmax set: %M kb\"")
-        self.shfile.write(" -o %s -a " % self.timeFile)
-        self.shfile.write("./toy -suppress-prompts -use-mcjit=false -input-IR=%s < %s > %s-mcjit.out 2> %s-mcjit.err\n" % (irname, callname, rootname, rootname))
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
+        self.shfile.write(" -o {0!s} -a ".format(self.timeFile))
+        self.shfile.write("./toy -suppress-prompts -use-mcjit=false -input-IR={0!s} < {1!s} > {2!s}-mcjit.out 2> {3!s}-mcjit.err\n".format(irname, callname, rootname, rootname))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
 
 class LibScriptGenerator:
     """Used to generate a bash script which will invoke the toy and time it"""
@@ -37,7 +37,7 @@ class LibScriptGenerator:
         self.shfile = open(filename, 'w')
 
     def writeLibGenCall(self, libname, irname):
-        self.shfile.write("./toy -suppress-prompts -use-mcjit=false -dump-modules < %s 2> %s\n" % (libname, irname))
+        self.shfile.write("./toy -suppress-prompts -use-mcjit=false -dump-modules < {0!s} 2> {1!s}\n".format(libname, irname))
 
 def splitScript(inputname, libGenScript, timingScript):
   rootname = inputname[:-2]
@@ -47,7 +47,7 @@ def splitScript(inputname, libGenScript, timingScript):
   infile = open(inputname, "r")
   libfile = open(libname, "w")
   callfile = open(callname, "w")
-  print "Splitting %s into %s and %s" % (inputname, callname, libname)
+  print "Splitting {0!s} into {1!s} and {2!s}".format(inputname, callname, libname)
   for line in infile:
     if not line.startswith("#"):
       if line.startswith("print"):

--- a/examples/Kaleidoscope/MCJIT/lazy/genk-timing.py
+++ b/examples/Kaleidoscope/MCJIT/lazy/genk-timing.py
@@ -8,26 +8,26 @@ class TimingScriptGenerator:
     def __init__(self, scriptname, outputname):
         self.timeFile = outputname
         self.shfile = open(scriptname, 'w')
-        self.shfile.write("echo \"\" > %s\n" % self.timeFile)
+        self.shfile.write("echo \"\" > {0!s}\n".format(self.timeFile))
 
     def writeTimingCall(self, filename, numFuncs, funcsCalled, totalCalls):
         """Echo some comments and invoke both versions of toy"""
         rootname = filename
         if '.' in filename:
             rootname = filename[:filename.rfind('.')]
-        self.shfile.write("echo \"%s: Calls %d of %d functions, %d total\" >> %s\n" % (filename, funcsCalled, numFuncs, totalCalls, self.timeFile))
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
-        self.shfile.write("echo \"With MCJIT\" >> %s\n" % self.timeFile)
+        self.shfile.write("echo \"{0!s}: Calls {1:d} of {2:d} functions, {3:d} total\" >> {4!s}\n".format(filename, funcsCalled, numFuncs, totalCalls, self.timeFile))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
+        self.shfile.write("echo \"With MCJIT\" >> {0!s}\n".format(self.timeFile))
         self.shfile.write("/usr/bin/time -f \"Command %C\\n\\tuser time: %U s\\n\\tsytem time: %S s\\n\\tmax set: %M kb\"")
-        self.shfile.write(" -o %s -a " % self.timeFile)
-        self.shfile.write("./toy-mcjit < %s > %s-mcjit.out 2> %s-mcjit.err\n" % (filename, rootname, rootname))
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
-        self.shfile.write("echo \"With JIT\" >> %s\n" % self.timeFile)
+        self.shfile.write(" -o {0!s} -a ".format(self.timeFile))
+        self.shfile.write("./toy-mcjit < {0!s} > {1!s}-mcjit.out 2> {2!s}-mcjit.err\n".format(filename, rootname, rootname))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
+        self.shfile.write("echo \"With JIT\" >> {0!s}\n".format(self.timeFile))
         self.shfile.write("/usr/bin/time -f \"Command %C\\n\\tuser time: %U s\\n\\tsytem time: %S s\\n\\tmax set: %M kb\"")
-        self.shfile.write(" -o %s -a " % self.timeFile)
-        self.shfile.write("./toy-jit < %s > %s-jit.out 2> %s-jit.err\n" % (filename, rootname, rootname))
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
-        self.shfile.write("echo \"\" >> %s\n" % self.timeFile)
+        self.shfile.write(" -o {0!s} -a ".format(self.timeFile))
+        self.shfile.write("./toy-jit < {0!s} > {1!s}-jit.out 2> {2!s}-jit.err\n".format(filename, rootname, rootname))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
+        self.shfile.write("echo \"\" >> {0!s}\n".format(self.timeFile))
 
 class KScriptGenerator:
     """Used to generate random Kaleidoscope code"""
@@ -116,21 +116,21 @@ class KScriptGenerator:
         if shouldCallFunc:
             funcToCall = random.randrange(1, self.lastFuncNum - 1)
             self.updateFunctionCallMap(self.lastFuncNum, funcToCall)
-            self.writeln("  %s = func%d(%s, %s) :" % (LValue, funcToCall, LHS, RHS))
+            self.writeln("  {0!s} = func{1:d}({2!s}, {3!s}) :".format(LValue, funcToCall, LHS, RHS))
         else:
             possibleOperations = ["+", "-", "*", "/"]
             operation = random.choice(possibleOperations)
             if operation == "-":
                 # Don't let our intermediate value become zero
                 # This is complicated by the fact that '<' is our only comparison operator
-                self.writeln("  if %s < %s then" % (LHS, RHS))
-                self.writeln("    %s = %s %s %s" % (LValue, LHS, operation, RHS))
-                self.writeln("  else if %s < %s then" % (RHS, LHS))
-                self.writeln("    %s = %s %s %s" % (LValue, LHS, operation, RHS))
+                self.writeln("  if {0!s} < {1!s} then".format(LHS, RHS))
+                self.writeln("    {0!s} = {1!s} {2!s} {3!s}".format(LValue, LHS, operation, RHS))
+                self.writeln("  else if {0!s} < {1!s} then".format(RHS, LHS))
+                self.writeln("    {0!s} = {1!s} {2!s} {3!s}".format(LValue, LHS, operation, RHS))
                 self.writeln("  else")
-                self.writeln("    %s = %s %s %f :" % (LValue, LHS, operation, random.uniform(1, 100)))
+                self.writeln("    {0!s} = {1!s} {2!s} {3:f} :".format(LValue, LHS, operation, random.uniform(1, 100)))
             else:
-                self.writeln("  %s = %s %s %s :" % (LValue, LHS, operation, RHS))
+                self.writeln("  {0!s} = {1!s} {2!s} {3!s} :".format(LValue, LHS, operation, RHS))
 
     def getNextFuncNum(self):
         result = self.nextFuncNum
@@ -140,8 +140,8 @@ class KScriptGenerator:
 
     def writeFunction(self, elements):
         funcNum = self.getNextFuncNum()
-        self.writeComment("Auto-generated function number %d" % funcNum)
-        self.writeln("def func%d(X Y)" % funcNum)
+        self.writeComment("Auto-generated function number {0:d}".format(funcNum))
+        self.writeln("def func{0:d}(X Y)".format(funcNum))
         self.writeln("  var temp1 = X,")
         self.writeln("      temp2 = Y,")
         self.writeln("      temp3 in")
@@ -164,26 +164,24 @@ class KScriptGenerator:
         self.writeComment("Call the last function")
         arg1 = random.uniform(1, 100)
         arg2 = random.uniform(1, 100)
-        self.writeln("printresult(%d, func%d(%f, %f) )" % (self.lastFuncNum, self.lastFuncNum, arg1, arg2))
+        self.writeln("printresult({0:d}, func{1:d}({2:f}, {3:f}) )".format(self.lastFuncNum, self.lastFuncNum, arg1, arg2))
         self.writeEmptyLine()
         self.updateCalledFunctionList(self.lastFuncNum)
 
     def writeFinalFunctionCounts(self):
-        self.writeComment("Called %d of %d functions" % (len(self.calledFunctions), self.lastFuncNum))
+        self.writeComment("Called {0:d} of {1:d} functions".format(len(self.calledFunctions), self.lastFuncNum))
 
 def generateKScript(filename, numFuncs, elementsPerFunc, funcsBetweenExec, callWeighting, timingScript):
     """ Generate a random Kaleidoscope script based on the given parameters """
     print "Generating " + filename
-    print("  %d functions, %d elements per function, %d functions between execution" %
-          (numFuncs, elementsPerFunc, funcsBetweenExec))
-    print("  Call weighting = %f" % callWeighting)
+    print("  {0:d} functions, {1:d} elements per function, {2:d} functions between execution".format(numFuncs, elementsPerFunc, funcsBetweenExec))
+    print("  Call weighting = {0:f}".format(callWeighting))
     script = KScriptGenerator(filename)
     script.setCallWeighting(callWeighting)
     script.writeComment("===========================================================================")
     script.writeComment("Auto-generated script")
-    script.writeComment("  %d functions, %d elements per function, %d functions between execution"
-                         % (numFuncs, elementsPerFunc, funcsBetweenExec))
-    script.writeComment("  call weighting = %f" % callWeighting)
+    script.writeComment("  {0:d} functions, {1:d} elements per function, {2:d} functions between execution".format(numFuncs, elementsPerFunc, funcsBetweenExec))
+    script.writeComment("  call weighting = {0:f}".format(callWeighting))
     script.writeComment("===========================================================================")
     script.writeEmptyLine()
     script.writePredefinedFunctions()
@@ -200,7 +198,7 @@ def generateKScript(filename, numFuncs, elementsPerFunc, funcsBetweenExec, callW
     script.writeEmptyLine()
     script.writeFinalFunctionCounts()
     funcsCalled = len(script.calledFunctions)
-    print "  Called %d of %d functions, %d total" % (funcsCalled, numFuncs, script.totalCallsExecuted)
+    print "  Called {0:d} of {1:d} functions, {2:d} total".format(funcsCalled, numFuncs, script.totalCallsExecuted)
     timingScript.writeTimingCall(filename, numFuncs, funcsCalled, script.totalCallsExecuted)
 
 # Execution begins here
@@ -214,6 +212,6 @@ dataSets = [(5000, 3,  50, 0.50), (5000, 10, 100, 0.10), (5000, 10, 5, 0.10), (5
 
 # Generate the code
 for (numFuncs, elementsPerFunc, funcsBetweenExec, callWeighting) in dataSets:
-    filename = "test-%d-%d-%d-%d.k" % (numFuncs, elementsPerFunc, funcsBetweenExec, int(callWeighting * 100))
+    filename = "test-{0:d}-{1:d}-{2:d}-{3:d}.k".format(numFuncs, elementsPerFunc, funcsBetweenExec, int(callWeighting * 100))
     generateKScript(filename, numFuncs, elementsPerFunc, funcsBetweenExec, callWeighting, timingScript)
 print "All done!"

--- a/test/CodeGen/SystemZ/Large/branch-range-01.py
+++ b/test/CodeGen/SystemZ/Large/branch-range-01.py
@@ -76,30 +76,30 @@ print '  br label %before0'
 print ''
 
 for i in xrange(branch_blocks):
-    next = 'before%d' % (i + 1) if i + 1 < branch_blocks else 'main'
-    print 'before%d:' % i
-    print '  %%bstop%d = getelementptr i32, i32 *%%stop, i64 %d' % (i, i)
-    print '  %%bcur%d = load i32 , i32 *%%bstop%d' % (i, i)
-    print '  %%btest%d = icmp eq i32 %%limit, %%bcur%d' % (i, i)
-    print '  br i1 %%btest%d, label %%after0, label %%%s' % (i, next)
+    next = 'before{0:d}'.format((i + 1)) if i + 1 < branch_blocks else 'main'
+    print 'before{0:d}:'.format(i)
+    print '  %bstop{0:d} = getelementptr i32, i32 *%stop, i64 {1:d}'.format(i, i)
+    print '  %bcur{0:d} = load i32 , i32 *%bstop{1:d}'.format(i, i)
+    print '  %btest{0:d} = icmp eq i32 %limit, %bcur{1:d}'.format(i, i)
+    print '  br i1 %btest{0:d}, label %after0, label %{1!s}'.format(i, next)
     print ''
 
-print '%s:' % next
+print '{0!s}:'.format(next)
 a, b = 1, 1
 for i in xrange(0, main_size, 6):
     a, b = b, a + b
     offset = 4096 + b % 500000
     value = a % 256
-    print '  %%ptr%d = getelementptr i8, i8 *%%base, i64 %d' % (i, offset)
-    print '  store volatile i8 %d, i8 *%%ptr%d' % (value, i)
+    print '  %ptr{0:d} = getelementptr i8, i8 *%base, i64 {1:d}'.format(i, offset)
+    print '  store volatile i8 {0:d}, i8 *%ptr{1:d}'.format(value, i)
 
 for i in xrange(branch_blocks):
-    print '  %%astop%d = getelementptr i32, i32 *%%stop, i64 %d' % (i, i + 25)
-    print '  %%acur%d = load i32 , i32 *%%astop%d' % (i, i)
-    print '  %%atest%d = icmp eq i32 %%limit, %%acur%d' % (i, i)
-    print '  br i1 %%atest%d, label %%main, label %%after%d' % (i, i)
+    print '  %astop{0:d} = getelementptr i32, i32 *%stop, i64 {1:d}'.format(i, i + 25)
+    print '  %acur{0:d} = load i32 , i32 *%astop{1:d}'.format(i, i)
+    print '  %atest{0:d} = icmp eq i32 %limit, %acur{1:d}'.format(i, i)
+    print '  br i1 %atest{0:d}, label %main, label %after{1:d}'.format(i, i)
     print ''
-    print 'after%d:' % i
+    print 'after{0:d}:'.format(i)
 
 print '  ret void'
 print '}'

--- a/test/CodeGen/SystemZ/Large/branch-range-02.py
+++ b/test/CodeGen/SystemZ/Large/branch-range-02.py
@@ -67,16 +67,16 @@ a, b = 1, 1
 for i in xrange(blocks):
     a, b = b, a + b
     value = a % 256
-    next = 'b%d' % (i + 1) if i + 1 < blocks else 'end'
+    next = 'b{0:d}'.format((i + 1)) if i + 1 < blocks else 'end'
     other = 'end' if 2 * i < blocks else 'b0'
-    print 'b%d:' % i
-    print '  store volatile i8 %d, i8 *%%base' % value
-    print '  %%astop%d = getelementptr i32, i32 *%%stop, i64 %d' % (i, i)
-    print '  %%acur%d = load i32 , i32 *%%astop%d' % (i, i)
-    print '  %%atest%d = icmp eq i32 %%limit, %%acur%d' % (i, i)
-    print '  br i1 %%atest%d, label %%%s, label %%%s' % (i, other, next)
+    print 'b{0:d}:'.format(i)
+    print '  store volatile i8 {0:d}, i8 *%base'.format(value)
+    print '  %astop{0:d} = getelementptr i32, i32 *%stop, i64 {1:d}'.format(i, i)
+    print '  %acur{0:d} = load i32 , i32 *%astop{1:d}'.format(i, i)
+    print '  %atest{0:d} = icmp eq i32 %limit, %acur{1:d}'.format(i, i)
+    print '  br i1 %atest{0:d}, label %{1!s}, label %{2!s}'.format(i, other, next)
 
 print ''
-print '%s:' % next
+print '{0!s}:'.format(next)
 print '  ret void'
 print '}'

--- a/test/CodeGen/SystemZ/Large/branch-range-03.py
+++ b/test/CodeGen/SystemZ/Large/branch-range-03.py
@@ -76,32 +76,32 @@ print '  br label %before0'
 print ''
 
 for i in xrange(branch_blocks):
-    next = 'before%d' % (i + 1) if i + 1 < branch_blocks else 'main'
-    print 'before%d:' % i
-    print '  %%bstop%d = getelementptr i8, i8 *%%stop, i64 %d' % (i, i)
-    print '  %%bcur%d = load i8 , i8 *%%bstop%d' % (i, i)
-    print '  %%bext%d = sext i8 %%bcur%d to i32' % (i, i)
-    print '  %%btest%d = icmp eq i32 %%limit, %%bext%d' % (i, i)
-    print '  br i1 %%btest%d, label %%after0, label %%%s' % (i, next)
+    next = 'before{0:d}'.format((i + 1)) if i + 1 < branch_blocks else 'main'
+    print 'before{0:d}:'.format(i)
+    print '  %bstop{0:d} = getelementptr i8, i8 *%stop, i64 {1:d}'.format(i, i)
+    print '  %bcur{0:d} = load i8 , i8 *%bstop{1:d}'.format(i, i)
+    print '  %bext{0:d} = sext i8 %bcur{1:d} to i32'.format(i, i)
+    print '  %btest{0:d} = icmp eq i32 %limit, %bext{1:d}'.format(i, i)
+    print '  br i1 %btest{0:d}, label %after0, label %{1!s}'.format(i, next)
     print ''
 
-print '%s:' % next
+print '{0!s}:'.format(next)
 a, b = 1, 1
 for i in xrange(0, main_size, 6):
     a, b = b, a + b
     offset = 4096 + b % 500000
     value = a % 256
-    print '  %%ptr%d = getelementptr i8, i8 *%%base, i64 %d' % (i, offset)
-    print '  store volatile i8 %d, i8 *%%ptr%d' % (value, i)
+    print '  %ptr{0:d} = getelementptr i8, i8 *%base, i64 {1:d}'.format(i, offset)
+    print '  store volatile i8 {0:d}, i8 *%ptr{1:d}'.format(value, i)
 
 for i in xrange(branch_blocks):
-    print '  %%astop%d = getelementptr i8, i8 *%%stop, i64 %d' % (i, i + 25)
-    print '  %%acur%d = load i8 , i8 *%%astop%d' % (i, i)
-    print '  %%aext%d = sext i8 %%acur%d to i32' % (i, i)
-    print '  %%atest%d = icmp eq i32 %%limit, %%aext%d' % (i, i)
-    print '  br i1 %%atest%d, label %%main, label %%after%d' % (i, i)
+    print '  %astop{0:d} = getelementptr i8, i8 *%stop, i64 {1:d}'.format(i, i + 25)
+    print '  %acur{0:d} = load i8 , i8 *%astop{1:d}'.format(i, i)
+    print '  %aext{0:d} = sext i8 %acur{1:d} to i32'.format(i, i)
+    print '  %atest{0:d} = icmp eq i32 %limit, %aext{1:d}'.format(i, i)
+    print '  br i1 %atest{0:d}, label %main, label %after{1:d}'.format(i, i)
     print ''
-    print 'after%d:' % i
+    print 'after{0:d}:'.format(i)
 
 print '  ret void'
 print '}'

--- a/test/CodeGen/SystemZ/Large/branch-range-04.py
+++ b/test/CodeGen/SystemZ/Large/branch-range-04.py
@@ -80,32 +80,32 @@ print '  br label %before0'
 print ''
 
 for i in xrange(branch_blocks):
-    next = 'before%d' % (i + 1) if i + 1 < branch_blocks else 'main'
-    print 'before%d:' % i
-    print '  %%bstop%d = getelementptr i8, i8 *%%stop, i64 %d' % (i, i)
-    print '  %%bcur%d = load i8 , i8 *%%bstop%d' % (i, i)
-    print '  %%bext%d = sext i8 %%bcur%d to i64' % (i, i)
-    print '  %%btest%d = icmp eq i64 %%limit, %%bext%d' % (i, i)
-    print '  br i1 %%btest%d, label %%after0, label %%%s' % (i, next)
+    next = 'before{0:d}'.format((i + 1)) if i + 1 < branch_blocks else 'main'
+    print 'before{0:d}:'.format(i)
+    print '  %bstop{0:d} = getelementptr i8, i8 *%stop, i64 {1:d}'.format(i, i)
+    print '  %bcur{0:d} = load i8 , i8 *%bstop{1:d}'.format(i, i)
+    print '  %bext{0:d} = sext i8 %bcur{1:d} to i64'.format(i, i)
+    print '  %btest{0:d} = icmp eq i64 %limit, %bext{1:d}'.format(i, i)
+    print '  br i1 %btest{0:d}, label %after0, label %{1!s}'.format(i, next)
     print ''
 
-print '%s:' % next
+print '{0!s}:'.format(next)
 a, b = 1, 1
 for i in xrange(0, main_size, 6):
     a, b = b, a + b
     offset = 4096 + b % 500000
     value = a % 256
-    print '  %%ptr%d = getelementptr i8, i8 *%%base, i64 %d' % (i, offset)
-    print '  store volatile i8 %d, i8 *%%ptr%d' % (value, i)
+    print '  %ptr{0:d} = getelementptr i8, i8 *%base, i64 {1:d}'.format(i, offset)
+    print '  store volatile i8 {0:d}, i8 *%ptr{1:d}'.format(value, i)
 
 for i in xrange(branch_blocks):
-    print '  %%astop%d = getelementptr i8, i8 *%%stop, i64 %d' % (i, i + 25)
-    print '  %%acur%d = load i8 , i8 *%%astop%d' % (i, i)
-    print '  %%aext%d = sext i8 %%acur%d to i64' % (i, i)
-    print '  %%atest%d = icmp eq i64 %%limit, %%aext%d' % (i, i)
-    print '  br i1 %%atest%d, label %%main, label %%after%d' % (i, i)
+    print '  %astop{0:d} = getelementptr i8, i8 *%stop, i64 {1:d}'.format(i, i + 25)
+    print '  %acur{0:d} = load i8 , i8 *%astop{1:d}'.format(i, i)
+    print '  %aext{0:d} = sext i8 %acur{1:d} to i64'.format(i, i)
+    print '  %atest{0:d} = icmp eq i64 %limit, %aext{1:d}'.format(i, i)
+    print '  br i1 %atest{0:d}, label %main, label %after{1:d}'.format(i, i)
     print ''
-    print 'after%d:' % i
+    print 'after{0:d}:'.format(i)
 
 print '  ret void'
 print '}'

--- a/test/CodeGen/SystemZ/Large/branch-range-05.py
+++ b/test/CodeGen/SystemZ/Large/branch-range-05.py
@@ -80,30 +80,30 @@ print '  br label %before0'
 print ''
 
 for i in xrange(branch_blocks):
-    next = 'before%d' % (i + 1) if i + 1 < branch_blocks else 'main'
-    print 'before%d:' % i
-    print '  %%bcur%d = load i8 , i8 *%%stop' % i
-    print '  %%bext%d = sext i8 %%bcur%d to i32' % (i, i)
-    print '  %%btest%d = icmp slt i32 %%bext%d, %d' % (i, i, i + 50)
-    print '  br i1 %%btest%d, label %%after0, label %%%s' % (i, next)
+    next = 'before{0:d}'.format((i + 1)) if i + 1 < branch_blocks else 'main'
+    print 'before{0:d}:'.format(i)
+    print '  %bcur{0:d} = load i8 , i8 *%stop'.format(i)
+    print '  %bext{0:d} = sext i8 %bcur{1:d} to i32'.format(i, i)
+    print '  %btest{0:d} = icmp slt i32 %bext{1:d}, {2:d}'.format(i, i, i + 50)
+    print '  br i1 %btest{0:d}, label %after0, label %{1!s}'.format(i, next)
     print ''
 
-print '%s:' % next
+print '{0!s}:'.format(next)
 a, b = 1, 1
 for i in xrange(0, main_size, 6):
     a, b = b, a + b
     offset = 4096 + b % 500000
     value = a % 256
-    print '  %%ptr%d = getelementptr i8, i8 *%%base, i64 %d' % (i, offset)
-    print '  store volatile i8 %d, i8 *%%ptr%d' % (value, i)
+    print '  %ptr{0:d} = getelementptr i8, i8 *%base, i64 {1:d}'.format(i, offset)
+    print '  store volatile i8 {0:d}, i8 *%ptr{1:d}'.format(value, i)
 
 for i in xrange(branch_blocks):
-    print '  %%acur%d = load i8 , i8 *%%stop' % i
-    print '  %%aext%d = sext i8 %%acur%d to i32' % (i, i)
-    print '  %%atest%d = icmp slt i32 %%aext%d, %d' % (i, i, i + 100)
-    print '  br i1 %%atest%d, label %%main, label %%after%d' % (i, i)
+    print '  %acur{0:d} = load i8 , i8 *%stop'.format(i)
+    print '  %aext{0:d} = sext i8 %acur{1:d} to i32'.format(i, i)
+    print '  %atest{0:d} = icmp slt i32 %aext{1:d}, {2:d}'.format(i, i, i + 100)
+    print '  br i1 %atest{0:d}, label %main, label %after{1:d}'.format(i, i)
     print ''
-    print 'after%d:' % i
+    print 'after{0:d}:'.format(i)
 
 print '  ret void'
 print '}'

--- a/test/CodeGen/SystemZ/Large/branch-range-06.py
+++ b/test/CodeGen/SystemZ/Large/branch-range-06.py
@@ -80,30 +80,30 @@ print '  br label %before0'
 print ''
 
 for i in xrange(branch_blocks):
-    next = 'before%d' % (i + 1) if i + 1 < branch_blocks else 'main'
-    print 'before%d:' % i
-    print '  %%bcur%d = load i8 , i8 *%%stop' % i
-    print '  %%bext%d = sext i8 %%bcur%d to i64' % (i, i)
-    print '  %%btest%d = icmp slt i64 %%bext%d, %d' % (i, i, i + 50)
-    print '  br i1 %%btest%d, label %%after0, label %%%s' % (i, next)
+    next = 'before{0:d}'.format((i + 1)) if i + 1 < branch_blocks else 'main'
+    print 'before{0:d}:'.format(i)
+    print '  %bcur{0:d} = load i8 , i8 *%stop'.format(i)
+    print '  %bext{0:d} = sext i8 %bcur{1:d} to i64'.format(i, i)
+    print '  %btest{0:d} = icmp slt i64 %bext{1:d}, {2:d}'.format(i, i, i + 50)
+    print '  br i1 %btest{0:d}, label %after0, label %{1!s}'.format(i, next)
     print ''
 
-print '%s:' % next
+print '{0!s}:'.format(next)
 a, b = 1, 1
 for i in xrange(0, main_size, 6):
     a, b = b, a + b
     offset = 4096 + b % 500000
     value = a % 256
-    print '  %%ptr%d = getelementptr i8, i8 *%%base, i64 %d' % (i, offset)
-    print '  store volatile i8 %d, i8 *%%ptr%d' % (value, i)
+    print '  %ptr{0:d} = getelementptr i8, i8 *%base, i64 {1:d}'.format(i, offset)
+    print '  store volatile i8 {0:d}, i8 *%ptr{1:d}'.format(value, i)
 
 for i in xrange(branch_blocks):
-    print '  %%acur%d = load i8 , i8 *%%stop' % i
-    print '  %%aext%d = sext i8 %%acur%d to i64' % (i, i)
-    print '  %%atest%d = icmp slt i64 %%aext%d, %d' % (i, i, i + 100)
-    print '  br i1 %%atest%d, label %%main, label %%after%d' % (i, i)
+    print '  %acur{0:d} = load i8 , i8 *%stop'.format(i)
+    print '  %aext{0:d} = sext i8 %acur{1:d} to i64'.format(i, i)
+    print '  %atest{0:d} = icmp slt i64 %aext{1:d}, {2:d}'.format(i, i, i + 100)
+    print '  br i1 %atest{0:d}, label %main, label %after{1:d}'.format(i, i)
     print ''
-    print 'after%d:' % i
+    print 'after{0:d}:'.format(i)
 
 print '  ret void'
 print '}'

--- a/test/CodeGen/SystemZ/Large/branch-range-07.py
+++ b/test/CodeGen/SystemZ/Large/branch-range-07.py
@@ -39,13 +39,13 @@ print 'define void @f1(i8 *%base, i32 *%counts) {'
 print 'entry:'
 
 for i in xrange(branch_blocks - 1, -1, -1):
-    print '  %%countptr%d = getelementptr i32, i32 *%%counts, i64 %d' % (i, i)
-    print '  %%initcount%d = load i32 , i32 *%%countptr%d' % (i, i)
-    print '  br label %%loop%d' % i
+    print '  %countptr{0:d} = getelementptr i32, i32 *%counts, i64 {1:d}'.format(i, i)
+    print '  %initcount{0:d} = load i32 , i32 *%countptr{1:d}'.format(i, i)
+    print '  br label %loop{0:d}'.format(i)
     
-    print 'loop%d:' % i
-    block1 = 'entry' if i == branch_blocks - 1 else 'loop%d' % (i + 1)
-    block2 = 'loop0' if i == 0 else 'after%d' % (i - 1)
+    print 'loop{0:d}:'.format(i)
+    block1 = 'entry' if i == branch_blocks - 1 else 'loop{0:d}'.format((i + 1))
+    block2 = 'loop0' if i == 0 else 'after{0:d}'.format((i - 1))
     print ('  %%count%d = phi i32 [ %%initcount%d, %%%s ],'
            ' [ %%nextcount%d, %%%s ]' % (i, i, block1, i, block2))
 
@@ -54,15 +54,15 @@ for i in xrange(0, main_size, 6):
     a, b = b, a + b
     offset = 4096 + b % 500000
     value = a % 256
-    print '  %%ptr%d = getelementptr i8, i8 *%%base, i64 %d' % (i, offset)
-    print '  store volatile i8 %d, i8 *%%ptr%d' % (value, i)
+    print '  %ptr{0:d} = getelementptr i8, i8 *%base, i64 {1:d}'.format(i, offset)
+    print '  store volatile i8 {0:d}, i8 *%ptr{1:d}'.format(value, i)
 
 for i in xrange(branch_blocks):
-    print '  %%nextcount%d = add i32 %%count%d, -1' % (i, i)
-    print '  %%test%d = icmp ne i32 %%nextcount%d, 0' % (i, i)
-    print '  br i1 %%test%d, label %%loop%d, label %%after%d' % (i, i, i)
+    print '  %nextcount{0:d} = add i32 %count{1:d}, -1'.format(i, i)
+    print '  %test{0:d} = icmp ne i32 %nextcount{1:d}, 0'.format(i, i)
+    print '  br i1 %test{0:d}, label %loop{1:d}, label %after{2:d}'.format(i, i, i)
     print ''
-    print 'after%d:' % i
+    print 'after{0:d}:'.format(i)
 
 print '  ret void'
 print '}'

--- a/test/CodeGen/SystemZ/Large/branch-range-08.py
+++ b/test/CodeGen/SystemZ/Large/branch-range-08.py
@@ -40,13 +40,13 @@ print 'define void @f1(i8 *%base, i64 *%counts) {'
 print 'entry:'
 
 for i in xrange(branch_blocks - 1, -1, -1):
-    print '  %%countptr%d = getelementptr i64, i64 *%%counts, i64 %d' % (i, i)
-    print '  %%initcount%d = load i64 , i64 *%%countptr%d' % (i, i)
-    print '  br label %%loop%d' % i
+    print '  %countptr{0:d} = getelementptr i64, i64 *%counts, i64 {1:d}'.format(i, i)
+    print '  %initcount{0:d} = load i64 , i64 *%countptr{1:d}'.format(i, i)
+    print '  br label %loop{0:d}'.format(i)
     
-    print 'loop%d:' % i
-    block1 = 'entry' if i == branch_blocks - 1 else 'loop%d' % (i + 1)
-    block2 = 'loop0' if i == 0 else 'after%d' % (i - 1)
+    print 'loop{0:d}:'.format(i)
+    block1 = 'entry' if i == branch_blocks - 1 else 'loop{0:d}'.format((i + 1))
+    block2 = 'loop0' if i == 0 else 'after{0:d}'.format((i - 1))
     print ('  %%count%d = phi i64 [ %%initcount%d, %%%s ],'
            ' [ %%nextcount%d, %%%s ]' % (i, i, block1, i, block2))
 
@@ -55,15 +55,15 @@ for i in xrange(0, main_size, 6):
     a, b = b, a + b
     offset = 4096 + b % 500000
     value = a % 256
-    print '  %%ptr%d = getelementptr i8, i8 *%%base, i64 %d' % (i, offset)
-    print '  store volatile i8 %d, i8 *%%ptr%d' % (value, i)
+    print '  %ptr{0:d} = getelementptr i8, i8 *%base, i64 {1:d}'.format(i, offset)
+    print '  store volatile i8 {0:d}, i8 *%ptr{1:d}'.format(value, i)
 
 for i in xrange(branch_blocks):
-    print '  %%nextcount%d = add i64 %%count%d, -1' % (i, i)
-    print '  %%test%d = icmp ne i64 %%nextcount%d, 0' % (i, i)
-    print '  br i1 %%test%d, label %%loop%d, label %%after%d' % (i, i, i)
+    print '  %nextcount{0:d} = add i64 %count{1:d}, -1'.format(i, i)
+    print '  %test{0:d} = icmp ne i64 %nextcount{1:d}, 0'.format(i, i)
+    print '  br i1 %test{0:d}, label %loop{1:d}, label %after{2:d}'.format(i, i, i)
     print ''
-    print 'after%d:' % i
+    print 'after{0:d}:'.format(i)
 
 print '  ret void'
 print '}'

--- a/test/CodeGen/SystemZ/Large/branch-range-09.py
+++ b/test/CodeGen/SystemZ/Large/branch-range-09.py
@@ -76,32 +76,32 @@ print '  br label %before0'
 print ''
 
 for i in xrange(branch_blocks):
-    next = 'before%d' % (i + 1) if i + 1 < branch_blocks else 'main'
-    print 'before%d:' % i
-    print '  %%bstop%d = getelementptr i8, i8 *%%stop, i64 %d' % (i, i)
-    print '  %%bcur%d = load i8 , i8 *%%bstop%d' % (i, i)
-    print '  %%bext%d = sext i8 %%bcur%d to i32' % (i, i)
-    print '  %%btest%d = icmp ult i32 %%limit, %%bext%d' % (i, i)
-    print '  br i1 %%btest%d, label %%after0, label %%%s' % (i, next)
+    next = 'before{0:d}'.format((i + 1)) if i + 1 < branch_blocks else 'main'
+    print 'before{0:d}:'.format(i)
+    print '  %bstop{0:d} = getelementptr i8, i8 *%stop, i64 {1:d}'.format(i, i)
+    print '  %bcur{0:d} = load i8 , i8 *%bstop{1:d}'.format(i, i)
+    print '  %bext{0:d} = sext i8 %bcur{1:d} to i32'.format(i, i)
+    print '  %btest{0:d} = icmp ult i32 %limit, %bext{1:d}'.format(i, i)
+    print '  br i1 %btest{0:d}, label %after0, label %{1!s}'.format(i, next)
     print ''
 
-print '%s:' % next
+print '{0!s}:'.format(next)
 a, b = 1, 1
 for i in xrange(0, main_size, 6):
     a, b = b, a + b
     offset = 4096 + b % 500000
     value = a % 256
-    print '  %%ptr%d = getelementptr i8, i8 *%%base, i64 %d' % (i, offset)
-    print '  store volatile i8 %d, i8 *%%ptr%d' % (value, i)
+    print '  %ptr{0:d} = getelementptr i8, i8 *%base, i64 {1:d}'.format(i, offset)
+    print '  store volatile i8 {0:d}, i8 *%ptr{1:d}'.format(value, i)
 
 for i in xrange(branch_blocks):
-    print '  %%astop%d = getelementptr i8, i8 *%%stop, i64 %d' % (i, i + 25)
-    print '  %%acur%d = load i8 , i8 *%%astop%d' % (i, i)
-    print '  %%aext%d = sext i8 %%acur%d to i32' % (i, i)
-    print '  %%atest%d = icmp ult i32 %%limit, %%aext%d' % (i, i)
-    print '  br i1 %%atest%d, label %%main, label %%after%d' % (i, i)
+    print '  %astop{0:d} = getelementptr i8, i8 *%stop, i64 {1:d}'.format(i, i + 25)
+    print '  %acur{0:d} = load i8 , i8 *%astop{1:d}'.format(i, i)
+    print '  %aext{0:d} = sext i8 %acur{1:d} to i32'.format(i, i)
+    print '  %atest{0:d} = icmp ult i32 %limit, %aext{1:d}'.format(i, i)
+    print '  br i1 %atest{0:d}, label %main, label %after{1:d}'.format(i, i)
     print ''
-    print 'after%d:' % i
+    print 'after{0:d}:'.format(i)
 
 print '  ret void'
 print '}'

--- a/test/CodeGen/SystemZ/Large/branch-range-10.py
+++ b/test/CodeGen/SystemZ/Large/branch-range-10.py
@@ -80,32 +80,32 @@ print '  br label %before0'
 print ''
 
 for i in xrange(branch_blocks):
-    next = 'before%d' % (i + 1) if i + 1 < branch_blocks else 'main'
-    print 'before%d:' % i
-    print '  %%bstop%d = getelementptr i8, i8 *%%stop, i64 %d' % (i, i)
-    print '  %%bcur%d = load i8 , i8 *%%bstop%d' % (i, i)
-    print '  %%bext%d = sext i8 %%bcur%d to i64' % (i, i)
-    print '  %%btest%d = icmp ult i64 %%limit, %%bext%d' % (i, i)
-    print '  br i1 %%btest%d, label %%after0, label %%%s' % (i, next)
+    next = 'before{0:d}'.format((i + 1)) if i + 1 < branch_blocks else 'main'
+    print 'before{0:d}:'.format(i)
+    print '  %bstop{0:d} = getelementptr i8, i8 *%stop, i64 {1:d}'.format(i, i)
+    print '  %bcur{0:d} = load i8 , i8 *%bstop{1:d}'.format(i, i)
+    print '  %bext{0:d} = sext i8 %bcur{1:d} to i64'.format(i, i)
+    print '  %btest{0:d} = icmp ult i64 %limit, %bext{1:d}'.format(i, i)
+    print '  br i1 %btest{0:d}, label %after0, label %{1!s}'.format(i, next)
     print ''
 
-print '%s:' % next
+print '{0!s}:'.format(next)
 a, b = 1, 1
 for i in xrange(0, main_size, 6):
     a, b = b, a + b
     offset = 4096 + b % 500000
     value = a % 256
-    print '  %%ptr%d = getelementptr i8, i8 *%%base, i64 %d' % (i, offset)
-    print '  store volatile i8 %d, i8 *%%ptr%d' % (value, i)
+    print '  %ptr{0:d} = getelementptr i8, i8 *%base, i64 {1:d}'.format(i, offset)
+    print '  store volatile i8 {0:d}, i8 *%ptr{1:d}'.format(value, i)
 
 for i in xrange(branch_blocks):
-    print '  %%astop%d = getelementptr i8, i8 *%%stop, i64 %d' % (i, i + 25)
-    print '  %%acur%d = load i8 , i8 *%%astop%d' % (i, i)
-    print '  %%aext%d = sext i8 %%acur%d to i64' % (i, i)
-    print '  %%atest%d = icmp ult i64 %%limit, %%aext%d' % (i, i)
-    print '  br i1 %%atest%d, label %%main, label %%after%d' % (i, i)
+    print '  %astop{0:d} = getelementptr i8, i8 *%stop, i64 {1:d}'.format(i, i + 25)
+    print '  %acur{0:d} = load i8 , i8 *%astop{1:d}'.format(i, i)
+    print '  %aext{0:d} = sext i8 %acur{1:d} to i64'.format(i, i)
+    print '  %atest{0:d} = icmp ult i64 %limit, %aext{1:d}'.format(i, i)
+    print '  br i1 %atest{0:d}, label %main, label %after{1:d}'.format(i, i)
     print ''
-    print 'after%d:' % i
+    print 'after{0:d}:'.format(i)
 
 print '  ret void'
 print '}'

--- a/test/CodeGen/SystemZ/Large/branch-range-11.py
+++ b/test/CodeGen/SystemZ/Large/branch-range-11.py
@@ -96,32 +96,32 @@ print '  br label %before0'
 print ''
 
 for i in xrange(branch_blocks):
-    next = 'before%d' % (i + 1) if i + 1 < branch_blocks else 'main'
-    print 'before%d:' % i
-    print '  %%bcur%da = load i32 , i32 *%%stopa' % i
-    print '  %%bcur%db = load i32 , i32 *%%stopb' % i
-    print '  %%bsub%d = sub i32 %%bcur%da, %%bcur%db' % (i, i, i)
-    print '  %%btest%d = icmp ult i32 %%bsub%d, %d' % (i, i, i + 50)
-    print '  br i1 %%btest%d, label %%after0, label %%%s' % (i, next)
+    next = 'before{0:d}'.format((i + 1)) if i + 1 < branch_blocks else 'main'
+    print 'before{0:d}:'.format(i)
+    print '  %bcur{0:d}a = load i32 , i32 *%stopa'.format(i)
+    print '  %bcur{0:d}b = load i32 , i32 *%stopb'.format(i)
+    print '  %bsub{0:d} = sub i32 %bcur{1:d}a, %bcur{2:d}b'.format(i, i, i)
+    print '  %btest{0:d} = icmp ult i32 %bsub{1:d}, {2:d}'.format(i, i, i + 50)
+    print '  br i1 %btest{0:d}, label %after0, label %{1!s}'.format(i, next)
     print ''
 
-print '%s:' % next
+print '{0!s}:'.format(next)
 a, b = 1, 1
 for i in xrange(0, main_size, 6):
     a, b = b, a + b
     offset = 4096 + b % 500000
     value = a % 256
-    print '  %%ptr%d = getelementptr i8, i8 *%%base, i64 %d' % (i, offset)
-    print '  store volatile i8 %d, i8 *%%ptr%d' % (value, i)
+    print '  %ptr{0:d} = getelementptr i8, i8 *%base, i64 {1:d}'.format(i, offset)
+    print '  store volatile i8 {0:d}, i8 *%ptr{1:d}'.format(value, i)
 
 for i in xrange(branch_blocks):
-    print '  %%acur%da = load i32 , i32 *%%stopa' % i
-    print '  %%acur%db = load i32 , i32 *%%stopb' % i
-    print '  %%asub%d = sub i32 %%acur%da, %%acur%db' % (i, i, i)
-    print '  %%atest%d = icmp ult i32 %%asub%d, %d' % (i, i, i + 100)
-    print '  br i1 %%atest%d, label %%main, label %%after%d' % (i, i)
+    print '  %acur{0:d}a = load i32 , i32 *%stopa'.format(i)
+    print '  %acur{0:d}b = load i32 , i32 *%stopb'.format(i)
+    print '  %asub{0:d} = sub i32 %acur{1:d}a, %acur{2:d}b'.format(i, i, i)
+    print '  %atest{0:d} = icmp ult i32 %asub{1:d}, {2:d}'.format(i, i, i + 100)
+    print '  br i1 %atest{0:d}, label %main, label %after{1:d}'.format(i, i)
     print ''
-    print 'after%d:' % i
+    print 'after{0:d}:'.format(i)
 
 print '  ret void'
 print '}'

--- a/test/CodeGen/SystemZ/Large/branch-range-12.py
+++ b/test/CodeGen/SystemZ/Large/branch-range-12.py
@@ -96,32 +96,32 @@ print '  br label %before0'
 print ''
 
 for i in xrange(branch_blocks):
-    next = 'before%d' % (i + 1) if i + 1 < branch_blocks else 'main'
-    print 'before%d:' % i
-    print '  %%bcur%da = load i64 , i64 *%%stopa' % i
-    print '  %%bcur%db = load i64 , i64 *%%stopb' % i
-    print '  %%bsub%d = sub i64 %%bcur%da, %%bcur%db' % (i, i, i)
-    print '  %%btest%d = icmp ult i64 %%bsub%d, %d' % (i, i, i + 50)
-    print '  br i1 %%btest%d, label %%after0, label %%%s' % (i, next)
+    next = 'before{0:d}'.format((i + 1)) if i + 1 < branch_blocks else 'main'
+    print 'before{0:d}:'.format(i)
+    print '  %bcur{0:d}a = load i64 , i64 *%stopa'.format(i)
+    print '  %bcur{0:d}b = load i64 , i64 *%stopb'.format(i)
+    print '  %bsub{0:d} = sub i64 %bcur{1:d}a, %bcur{2:d}b'.format(i, i, i)
+    print '  %btest{0:d} = icmp ult i64 %bsub{1:d}, {2:d}'.format(i, i, i + 50)
+    print '  br i1 %btest{0:d}, label %after0, label %{1!s}'.format(i, next)
     print ''
 
-print '%s:' % next
+print '{0!s}:'.format(next)
 a, b = 1, 1
 for i in xrange(0, main_size, 6):
     a, b = b, a + b
     offset = 4096 + b % 500000
     value = a % 256
-    print '  %%ptr%d = getelementptr i8, i8 *%%base, i64 %d' % (i, offset)
-    print '  store volatile i8 %d, i8 *%%ptr%d' % (value, i)
+    print '  %ptr{0:d} = getelementptr i8, i8 *%base, i64 {1:d}'.format(i, offset)
+    print '  store volatile i8 {0:d}, i8 *%ptr{1:d}'.format(value, i)
 
 for i in xrange(branch_blocks):
-    print '  %%acur%da = load i64 , i64 *%%stopa' % i
-    print '  %%acur%db = load i64 , i64 *%%stopb' % i
-    print '  %%asub%d = sub i64 %%acur%da, %%acur%db' % (i, i, i)
-    print '  %%atest%d = icmp ult i64 %%asub%d, %d' % (i, i, i + 100)
-    print '  br i1 %%atest%d, label %%main, label %%after%d' % (i, i)
+    print '  %acur{0:d}a = load i64 , i64 *%stopa'.format(i)
+    print '  %acur{0:d}b = load i64 , i64 *%stopb'.format(i)
+    print '  %asub{0:d} = sub i64 %acur{1:d}a, %acur{2:d}b'.format(i, i, i)
+    print '  %atest{0:d} = icmp ult i64 %asub{1:d}, {2:d}'.format(i, i, i + 100)
+    print '  br i1 %atest{0:d}, label %main, label %after{1:d}'.format(i, i)
     print ''
-    print 'after%d:' % i
+    print 'after{0:d}:'.format(i)
 
 print '  ret void'
 print '}'

--- a/test/CodeGen/SystemZ/Large/spill-01.py
+++ b/test/CodeGen/SystemZ/Large/spill-01.py
@@ -25,15 +25,15 @@ print ''
 print 'define void @f1(i64 *%base0, i64 *%base1) {'
 
 for i in range(count):
-    print '  %%ptr%d = getelementptr i64, i64 *%%base%d, i64 %d' % (i, i % 2, i / 2)
-    print '  %%val%d = load i64 , i64 *%%ptr%d' % (i, i)
+    print '  %ptr{0:d} = getelementptr i64, i64 *%base{1:d}, i64 {2:d}'.format(i, i % 2, i / 2)
+    print '  %val{0:d} = load i64 , i64 *%ptr{1:d}'.format(i, i)
     print ''
 
 print '  call void @foo()'
 print ''
 
 for i in range(count):
-    print '  store i64 %%val%d, i64 *%%ptr%d' % (i, i)
+    print '  store i64 %val{0:d}, i64 *%ptr{1:d}'.format(i, i)
 
 print ''
 print '  ret void'

--- a/test/CodeGen/SystemZ/Large/spill-02.py
+++ b/test/CodeGen/SystemZ/Large/spill-02.py
@@ -21,7 +21,7 @@
 # which is used as a base pointer.
 args = (8168 - 160) / 8 + (5 - 1)
 
-print 'declare i64 *@foo(i64 *%s)' % (', i64' * args)
+print 'declare i64 *@foo(i64 *{0!s})'.format((', i64' * args))
 print 'declare void @bar(i64 *)'
 print ''
 print 'define i64 @f1(i64 %foo) {'
@@ -30,22 +30,22 @@ print 'entry:'
 # Make the allocation big, so that it goes at the top of the frame.
 print '  %array = alloca [1000 x i64]'
 print '  %area = getelementptr [1000 x i64], [1000 x i64] *%array, i64 0, i64 0'
-print '  %%base = call i64 *@foo(i64 *%%area%s)' % (', i64 0' * args)
+print '  %base = call i64 *@foo(i64 *%area{0!s})'.format((', i64 0' * args))
 print ''
 
 # Make sure all GPRs are used.  One is needed for the stack pointer and
 # another for %base, so we need 14 live values.
 count = 14
 for i in range(count):
-    print '  %%ptr%d = getelementptr i64, i64 *%%base, i64 %d' % (i, i / 2)
-    print '  %%val%d = load volatile i64 , i64 *%%ptr%d' % (i, i)
+    print '  %ptr{0:d} = getelementptr i64, i64 *%base, i64 {1:d}'.format(i, i / 2)
+    print '  %val{0:d} = load volatile i64 , i64 *%ptr{1:d}'.format(i, i)
     print ''
 
 # Encourage the register allocator to give preference to these %vals
 # by using them several times.
 for j in range(4):
     for i in range(count):
-        print '  store volatile i64 %%val%d, i64 *%%ptr%d' % (i, i)
+        print '  store volatile i64 %val{0:d}, i64 *%ptr{1:d}'.format(i, i)
     print ''
 
 # Copy the incoming argument, which we expect to be spilled, to the frame
@@ -65,7 +65,7 @@ print 'skip:'
 # that they are live across the store of %foo.
 for j in range(4):
     for i in range(count):
-        print '  store volatile i64 %%val%d, i64 *%%ptr%d' % (i, i)
+        print '  store volatile i64 %val{0:d}, i64 *%ptr{1:d}'.format(i, i)
     print ''
 
 print '  call void @bar(i64 *%area)'

--- a/test/MC/COFF/bigobj.py
+++ b/test/MC/COFF/bigobj.py
@@ -19,8 +19,8 @@ num_sections = 65277
 # CHECK-NEXT: }
 
 for i in range(0, num_sections):
-	print("""	.section	.bss,"bw",discard,_b%d
-	.globl	_b%d                     # @b%d
-_b%d:
+	print("""	.section	.bss,"bw",discard,_b{0:d}
+	.globl	_b{1:d}                     # @b{2:d}
+_b{3:d}:
 	.byte	0                       # 0x0
-""" % (i, i, i, i))
+""".format(i, i, i, i))

--- a/test/tools/llvm-readobj/Inputs/relocs.py
+++ b/test/tools/llvm-readobj/Inputs/relocs.py
@@ -205,7 +205,7 @@ class ElfSection:
         else:
           r_info = (r_info & 0xFF00) | (r_type & 0xFF)
 
-        print("    %s" % relocs[ri][0])
+        print("    {0!s}".format(relocs[ri][0]))
         f.seek(pos)
         f.writeWord(r_info)
 
@@ -266,7 +266,7 @@ def patchElf(path, relocs):
   elif fileclass == 2:
     f.is64Bit = True
   else:
-    raise ValueError, "Unknown file class %x" % fileclass
+    raise ValueError, "Unknown file class {0:x}".format(fileclass)
 
   byteordering = f.uint8()
   if byteordering == 1:
@@ -274,7 +274,7 @@ def patchElf(path, relocs):
   elif byteordering == 2:
       f.isLSB = False
   else:
-      raise ValueError, "Unknown byte ordering %x" % byteordering
+      raise ValueError, "Unknown byte ordering {0:x}".format(byteordering)
 
   f.seek(18)
   e_machine = f.uint16()
@@ -339,7 +339,7 @@ def patchCoff(path, relocs):
   for i in range(section.relocation_count):
     virtual_addr = f.uint32()
     symtab_idx   = f.uint32()
-    print("    %s" % relocs[i][0])
+    print("    {0!s}".format(relocs[i][0]))
     f.writeUInt16(relocs[i][1])
 
 
@@ -375,7 +375,7 @@ def patchMacho(filename, relocs):
   elif magic == '\xCF\xFA\xED\xFE':
     f.isLSB, f.is64Bit = True, True
   else:
-    raise ValueError,"Not a Mach-O object file: %r (bad magic)" % path
+    raise ValueError,"Not a Mach-O object file: {0!r} (bad magic)".format(path)
 
   cputype = f.uint32()
   cpusubtype = f.uint32()
@@ -392,7 +392,7 @@ def patchMacho(filename, relocs):
     patchMachoLoadCommand(f, relocs)
 
   if f.tell() - start != loadCommandsSize:
-    raise ValueError,"%s: warning: invalid load commands size: %r" % (
+    raise ValueError,"{0!s}: warning: invalid load commands size: {1!r}".format(
       sys.argv[0], loadCommandsSize)
 
 def patchMachoLoadCommand(f, relocs):
@@ -408,7 +408,7 @@ def patchMachoLoadCommand(f, relocs):
     f.read(cmdSize - 8)
 
   if f.tell() - start != cmdSize:
-    raise ValueError,"%s: warning: invalid load command size: %r" % (
+    raise ValueError,"{0!s}: warning: invalid load command size: {1!r}".format(
       sys.argv[0], cmdSize)
 
 def patchMachoSegmentLoadCommand(f, relocs):
@@ -444,7 +444,7 @@ def patchMachoSection(f, relocs):
   f.seek(relocOffset)
   for i in range(numReloc):
     ri = i < len(relocs) and i or 0
-    print("    %s" % relocs[ri][0])
+    print("    {0!s}".format(relocs[ri][0]))
     word1 = f.uint32()
     pos = f.tell()
     value = f.uint32()

--- a/utils/Target/ARM/analyze-match-table.py
+++ b/utils/Target/ARM/analyze-match-table.py
@@ -37,9 +37,9 @@ def analyze_match_table(path):
     condcode_mnemonics = set(m for m in mnemonics
                              if 'MCK_CondCode' in mnemonic_flags[m])
     noncondcode_mnemonics = mnemonics - condcode_mnemonics
-    print ' || '.join('Mnemonic == "%s"' % m
+    print ' || '.join('Mnemonic == "{0!s}"'.format(m)
                       for m in ccout_mnemonics)
-    print ' || '.join('Mnemonic == "%s"' % m
+    print ' || '.join('Mnemonic == "{0!s}"'.format(m)
                       for m in noncondcode_mnemonics)
 
 def main():

--- a/utils/create_ladder_graph.py
+++ b/utils/create_ladder_graph.py
@@ -23,18 +23,18 @@ def main():
   rung1 = xrange(0, args.rungs, 2)
   rung2 = xrange(1, args.rungs, 2)
   for i in rung1:
-    print "rung1%d:" % i
+    print "rung1{0:d}:".format(i)
     print "*foo = x++;"
     if i != rung1[-1]:
-      print "if (*bar) goto rung1%d;" % (i+2)
-      print "else goto rung2%d;" % (i+1)
+      print "if (*bar) goto rung1{0:d};".format((i+2))
+      print "else goto rung2{0:d};".format((i+1))
     else:
-      print "goto rung2%d;" % (i+1)
+      print "goto rung2{0:d};".format((i+1))
   for i in rung2:
-    print "rung2%d:" % i
+    print "rung2{0:d}:".format(i)
     print "*foo = x++;"
     if i != rung2[-1]:
-      print "goto rung2%d;" % (i+2)
+      print "goto rung2{0:d};".format((i+2))
     else:
       print "return *foo;"
   print "}"

--- a/utils/lint/common_lint.py
+++ b/utils/lint/common_lint.py
@@ -23,7 +23,7 @@ def VerifyLineLength(filename, lines, max_length):
     length = len(line.rstrip('\n'))
     if length > max_length:
       lint.append((filename, line_num,
-                   'Line exceeds %d chars (%d)' % (max_length, length)))
+                   'Line exceeds {0:d} chars ({1:d})'.format(max_length, length)))
     line_num += 1
   return lint
 
@@ -89,7 +89,7 @@ def RunLintOverAllFiles(linter, filenames):
   for filename in filenames:
     file = open(filename, 'r')
     if not file:
-      print 'Cound not open %s' % filename
+      print 'Cound not open {0!s}'.format(filename)
       continue
     lines = file.readlines()
     lint.extend(linter.RunOnFile(filename, lines))

--- a/utils/lint/cpp_lint.py
+++ b/utils/lint/cpp_lint.py
@@ -44,7 +44,7 @@ def VerifyIncludes(filename, lines):
       if prev_config_header:
         if prev_config_header > curr_config_header:
           lint.append((filename, line_num,
-                       'Config headers not in order: "%s" before "%s"' % (
+                       'Config headers not in order: "{0!s}" before "{1!s}"'.format(
                          prev_config_header, curr_config_header)))
 
     # Process system headers
@@ -55,12 +55,12 @@ def VerifyIncludes(filename, lines):
       # Is it blacklisted?
       if curr_system_header in DISALLOWED_SYSTEM_HEADERS:
         lint.append((filename, line_num,
-                     'Disallowed system header: <%s>' % curr_system_header))
+                     'Disallowed system header: <{0!s}>'.format(curr_system_header)))
       elif prev_system_header:
         # Make sure system headers are alphabetized amongst themselves
         if prev_system_header > curr_system_header:
           lint.append((filename, line_num,
-                       'System headers not in order: <%s> before <%s>' % (
+                       'System headers not in order: <{0!s}> before <{1!s}>'.format(
                          prev_system_header, curr_system_header)))
 
       prev_system_header = curr_system_header
@@ -86,7 +86,7 @@ class CppLint(common_lint.BaseLint):
 def CppLintMain(filenames):
   all_lint = common_lint.RunLintOverAllFiles(CppLint(), filenames)
   for lint in all_lint:
-    print '%s:%d:%s' % (lint[0], lint[1], lint[2])
+    print '{0!s}:{1:d}:{2!s}'.format(lint[0], lint[1], lint[2])
   return 0
 
 

--- a/utils/lit/lit/LitConfig.py
+++ b/utils/lit/lit/LitConfig.py
@@ -38,9 +38,9 @@ class LitConfig:
 
         # Configuration files to look for when discovering test suites.
         self.config_prefix = config_prefix or 'lit'
-        self.config_name = '%s.cfg' % (self.config_prefix,)
-        self.site_config_name = '%s.site.cfg' % (self.config_prefix,)
-        self.local_config_name = '%s.local.cfg' % (self.config_prefix,)
+        self.config_name = '{0!s}.cfg'.format(self.config_prefix)
+        self.site_config_name = '{0!s}.site.cfg'.format(self.config_prefix)
+        self.local_config_name = '{0!s}.local.cfg'.format(self.config_prefix)
 
         self.numErrors = 0
         self.numWarnings = 0
@@ -62,7 +62,7 @@ class LitConfig:
         """load_config(config, path) - Load a config object from an alternate
         path."""
         if self.debug:
-            self.note('load_config from %r' % path)
+            self.note('load_config from {0!r}'.format(path))
         config.load_from_path(path, self)
         return config
 
@@ -100,9 +100,9 @@ class LitConfig:
         # Step out of _write_message, and then out of wrapper.
         f = f.f_back.f_back
         file,line,_,_,_ = inspect.getframeinfo(f)
-        location = '%s:%d' % (os.path.basename(file), line)
+        location = '{0!s}:{1:d}'.format(os.path.basename(file), line)
 
-        sys.stderr.write('%s: %s: %s: %s\n' % (self.progname, location,
+        sys.stderr.write('{0!s}: {1!s}: {2!s}: {3!s}\n'.format(self.progname, location,
                                                kind, message))
 
     def note(self, message):

--- a/utils/lit/lit/ProgressBar.py
+++ b/utils/lit/lit/ProgressBar.py
@@ -191,7 +191,7 @@ class SimpleProgressBar:
         for i in range(self.atIndex, next):
             idx = i % 5
             if idx == 0:
-                sys.stdout.write('%-2d' % (i*2))
+                sys.stdout.write('{0:<2d}'.format((i*2)))
             elif idx == 1:
                 pass # Skip second char
             elif idx < 4:
@@ -247,7 +247,7 @@ class ProgressBar:
         if self.cleared:
             sys.stdout.write(self.header)
             self.cleared = 0
-        prefix = '%3d%% ' % (percent*100,)
+        prefix = '{0:3d}% '.format(percent*100)
         suffix = ''
         if self.useETA:
             elapsed = time.time() - self.startTime
@@ -257,7 +257,7 @@ class ProgressBar:
                 h = eta//3600.
                 m = (eta//60) % 60
                 s = eta % 60
-                suffix = ' ETA: %02d:%02d:%02d'%(h,m,s)
+                suffix = ' ETA: {0:02d}:{1:02d}:{2:02d}'.format(h, m, s)
         barWidth = self.width - len(prefix) - len(suffix) - 2
         n = int(barWidth*percent)
         if len(message) < self.width:

--- a/utils/lit/lit/ShCommands.py
+++ b/utils/lit/lit/ShCommands.py
@@ -4,7 +4,7 @@ class Command:
         self.redirects = list(redirects)
 
     def __repr__(self):
-        return 'Command(%r, %r)' % (self.args, self.redirects)
+        return 'Command({0!r}, {1!r})'.format(self.args, self.redirects)
 
     def __eq__(self, other):
         if not isinstance(other, Command):
@@ -16,24 +16,24 @@ class Command:
     def toShell(self, file):
         for arg in self.args:
             if "'" not in arg:
-                quoted = "'%s'" % arg
+                quoted = "'{0!s}'".format(arg)
             elif '"' not in arg and '$' not in arg:
-                quoted = '"%s"' % arg
+                quoted = '"{0!s}"'.format(arg)
             else:
-                raise NotImplementedError('Unable to quote %r' % arg)
+                raise NotImplementedError('Unable to quote {0!r}'.format(arg))
             file.write(quoted)
 
             # For debugging / validation.
             import ShUtil
             dequoted = list(ShUtil.ShLexer(quoted).lex())
             if dequoted != [arg]:
-                raise NotImplementedError('Unable to quote %r' % arg)
+                raise NotImplementedError('Unable to quote {0!r}'.format(arg))
 
         for r in self.redirects:
             if len(r[0]) == 1:
-                file.write("%s '%s'" % (r[0][0], r[1]))
+                file.write("{0!s} '{1!s}'".format(r[0][0], r[1]))
             else:
-                file.write("%s%s '%s'" % (r[0][1], r[0][0], r[1]))
+                file.write("{0!s}{1!s} '{2!s}'".format(r[0][1], r[0][0], r[1]))
 
 class Pipeline:
     def __init__(self, commands, negate=False, pipe_err=False):
@@ -42,7 +42,7 @@ class Pipeline:
         self.pipe_err = pipe_err
 
     def __repr__(self):
-        return 'Pipeline(%r, %r, %r)' % (self.commands, self.negate,
+        return 'Pipeline({0!r}, {1!r}, {2!r})'.format(self.commands, self.negate,
                                          self.pipe_err)
 
     def __eq__(self, other):
@@ -70,7 +70,7 @@ class Seq:
         self.rhs = rhs
 
     def __repr__(self):
-        return 'Seq(%r, %r, %r)' % (self.lhs, self.op, self.rhs)
+        return 'Seq({0!r}, {1!r}, {2!r})'.format(self.lhs, self.op, self.rhs)
 
     def __eq__(self, other):
         if not isinstance(other, Seq):
@@ -81,5 +81,5 @@ class Seq:
 
     def toShell(self, file, pipefail=False):
         self.lhs.toShell(file, pipefail)
-        file.write(' %s\n' % self.op)
+        file.write(' {0!s}\n'.format(self.op))
         self.rhs.toShell(file, pipefail)

--- a/utils/lit/lit/ShUtil.py
+++ b/utils/lit/lit/ShUtil.py
@@ -76,7 +76,7 @@ class ShLexer:
                 self.eat()
                 if self.pos == self.end:
                     lit.util.warning(
-                        "escape at end of quoted argument in: %r" % self.data)
+                        "escape at end of quoted argument in: {0!r}".format(self.data))
                     return str
                 str += self.eat()
             else:
@@ -94,7 +94,7 @@ class ShLexer:
                 # character and backslash, otherwise it is preserved.
                 if self.pos == self.end:
                     lit.util.warning(
-                        "escape at end of quoted argument in: %r" % self.data)
+                        "escape at end of quoted argument in: {0!r}".format(self.data))
                     return str
                 c = self.eat()
                 if c == '"': # 
@@ -105,7 +105,7 @@ class ShLexer:
                     str += '\\' + c
             else:
                 str += c
-        lit.util.warning("missing quote character in %r" % self.data)
+        lit.util.warning("missing quote character in {0!r}".format(self.data))
         return str
     
     def lex_arg_checked(self, c):
@@ -117,10 +117,10 @@ class ShLexer:
         reference = self.lex_arg_slow(c)
         if res is not None:
             if res != reference:
-                raise ValueError("Fast path failure: %r != %r" % (
+                raise ValueError("Fast path failure: {0!r} != {1!r}".format(
                         res, reference))
             if self.pos != end:
-                raise ValueError("Fast path failure: %r != %r" % (
+                raise ValueError("Fast path failure: {0!r} != {1!r}".format(
                         self.pos, end))
         return reference
         
@@ -190,7 +190,7 @@ class ShParser:
         if not tok:
             raise ValueError("empty command!")
         if isinstance(tok, tuple):
-            raise ValueError("syntax error near unexpected token %r" % tok[0])
+            raise ValueError("syntax error near unexpected token {0!r}".format(tok[0]))
         
         args = [tok]
         redirects = []
@@ -215,7 +215,7 @@ class ShParser:
             op = self.lex()
             arg = self.lex()
             if not arg:
-                raise ValueError("syntax error near token %r" % op[0])
+                raise ValueError("syntax error near token {0!r}".format(op[0]))
             redirects.append((op, arg))
 
         return Command(args, redirects)
@@ -238,7 +238,7 @@ class ShParser:
 
             if not self.look():
                 raise ValueError(
-                    "missing argument to operator %r" % operator[0])
+                    "missing argument to operator {0!r}".format(operator[0]))
             
             # FIXME: Operator precedence!!
             lhs = Seq(lhs, operator[0], self.parse_pipeline())

--- a/utils/lit/lit/Test.py
+++ b/utils/lit/lit/Test.py
@@ -23,7 +23,7 @@ class ResultCode(object):
         self.isFailure = isFailure
 
     def __repr__(self):
-        return '%s%r' % (self.__class__.__name__,
+        return '{0!s}{1!r}'.format(self.__class__.__name__,
                          (self.name, self.isFailure))
 
 PASS        = ResultCode('PASS', False)
@@ -70,7 +70,7 @@ class RealMetricValue(MetricValue):
         self.value = value
 
     def format(self):
-        return '%.4f' % self.value
+        return '{0:.4f}'.format(self.value)
 
     def todata(self):
         return self.value
@@ -137,10 +137,10 @@ class Result(object):
         Each value must be an instance of a MetricValue subclass.
         """
         if name in self.metrics:
-            raise ValueError("result already includes metrics for %r" % (
-                    name,))
+            raise ValueError("result already includes metrics for {0!r}".format(
+                    name))
         if not isinstance(value, MetricValue):
-            raise TypeError("unexpected metric value: %r" % (value,))
+            raise TypeError("unexpected metric value: {0!r}".format(value))
         self.metrics[name] = value
 
 # Test classes.
@@ -248,7 +248,7 @@ class Test:
 
         xml = "<testcase classname='" + class_name + "' name='" + \
             test_name + "'"
-        xml += " time='%.2f'" % (self.result.elapsed,)
+        xml += " time='{0:.2f}'".format(self.result.elapsed)
         if self.result.code.isFailure:
             xml += ">\n\t<failure >\n" + escape(self.result.output)
             xml += "\n\t</failure>\n</testcase>"

--- a/utils/lit/lit/TestRunner.py
+++ b/utils/lit/lit/TestRunner.py
@@ -57,7 +57,7 @@ def executeShCmd(cmd, shenv, results):
                 res = executeShCmd(cmd.rhs, shenv, results)
             return res
 
-        raise ValueError('Unknown shell command: %r' % cmd.op)
+        raise ValueError('Unknown shell command: {0!r}'.format(cmd.op))
     assert isinstance(cmd, ShUtil.Pipeline)
 
     # Handle shell builtins first.
@@ -123,7 +123,7 @@ def executeShCmd(cmd, shenv, results):
             elif r[0] == ('<',):
                 redirects[0] = [r[1], 'r', None]
             else:
-                raise InternalShellError(j,"Unsupported redirect: %r" % (r,))
+                raise InternalShellError(j,"Unsupported redirect: {0!r}".format(r))
 
         # Map from the final redirections to something subprocess can handle.
         final_redirects = []
@@ -187,7 +187,7 @@ def executeShCmd(cmd, shenv, results):
         if not executable:
             executable = lit.util.which(args[0], cmd_shenv.env['PATH'])
         if not executable:
-            raise InternalShellError(j, '%r: command not found' % j.args[0])
+            raise InternalShellError(j, '{0!r}: command not found'.format(j.args[0]))
 
         # Replace uses of /dev/null with temporary files.
         if kAvoidDevNull:
@@ -302,7 +302,7 @@ def executeScriptInternal(test, litConfig, tmpBase, commands, cwd):
             cmds.append(ShUtil.ShParser(ln, litConfig.isWindows,
                                         test.config.pipefail).parse())
         except:
-            return lit.Test.Result(Test.FAIL, "shell parser error on: %r" % ln)
+            return lit.Test.Result(Test.FAIL, "shell parser error on: {0!r}".format(ln))
 
     cmd = cmds[0]
     for c in cmds[1:]:
@@ -319,10 +319,10 @@ def executeScriptInternal(test, litConfig, tmpBase, commands, cwd):
 
     out = err = ''
     for i,(cmd, cmd_out,cmd_err,res) in enumerate(results):
-        out += 'Command %d: %s\n' % (i, ' '.join('"%s"' % s for s in cmd.args))
-        out += 'Command %d Result: %r\n' % (i, res)
-        out += 'Command %d Output:\n%s\n\n' % (i, cmd_out)
-        out += 'Command %d Stderr:\n%s\n\n' % (i, cmd_err)
+        out += 'Command {0:d}: {1!s}\n'.format(i, ' '.join('"{0!s}"'.format(s) for s in cmd.args))
+        out += 'Command {0:d} Result: {1!r}\n'.format(i, res)
+        out += 'Command {0:d} Output:\n{1!s}\n\n'.format(i, cmd_out)
+        out += 'Command {0:d} Stderr:\n{1!s}\n\n'.format(i, cmd_err)
 
     return out, err, exitCode
 
@@ -382,7 +382,7 @@ def parseIntegratedTestScriptCommands(source_path, keywords):
     # version.
 
     keywords_re = re.compile(
-        to_bytes("(%s)(.*)\n" % ("|".join(k for k in keywords),)))
+        to_bytes("({0!s})(.*)\n".format("|".join(k for k in keywords))))
 
     f = open(source_path, 'rb')
     try:
@@ -515,8 +515,8 @@ def parseIntegratedTestScript(test, require_script=True):
             if not ln.strip():
                 break
         else:
-            raise ValueError("unknown script command type: %r" % (
-                    command_type,))
+            raise ValueError("unknown script command type: {0!r}".format(
+                    command_type))
 
     # Verify the script contains a run line.
     if require_script and not script:
@@ -533,20 +533,20 @@ def parseIntegratedTestScript(test, require_script=True):
     if missing_required_features:
         msg = ', '.join(missing_required_features)
         return lit.Test.Result(Test.UNSUPPORTED,
-                               "Test requires the following features: %s" % msg)
+                               "Test requires the following features: {0!s}".format(msg))
     unsupported_features = [f for f in unsupported
                             if f in test.config.available_features]
     if unsupported_features:
         msg = ', '.join(unsupported_features)
         return lit.Test.Result(Test.UNSUPPORTED,
-                    "Test is unsupported with the following features: %s" % msg)
+                    "Test is unsupported with the following features: {0!s}".format(msg))
 
     unsupported_targets = [f for f in unsupported
                            if f in test.suite.config.target_triple]
     if unsupported_targets:
       return lit.Test.Result(Test.UNSUPPORTED,
-                  "Test is unsupported with the following triple: %s" % (
-                      test.suite.config.target_triple,))
+                  "Test is unsupported with the following triple: {0!s}".format(
+                      test.suite.config.target_triple))
 
     if test.config.limit_to_features:
         # Check that we have one of the limit_to_features features in requires.
@@ -555,7 +555,7 @@ def parseIntegratedTestScript(test, require_script=True):
         if not limit_to_features_tests:
             msg = ', '.join(test.config.limit_to_features)
             return lit.Test.Result(Test.UNSUPPORTED,
-                 "Test requires one of the limit_to_features features %s" % msg)
+                 "Test requires one of the limit_to_features features {0!s}".format(msg))
 
     return script
 
@@ -578,14 +578,14 @@ def _runShTest(test, litConfig, useExternalSh, script, tmpBase):
         status = Test.FAIL
 
     # Form the output log.
-    output = """Script:\n--\n%s\n--\nExit Code: %d\n\n""" % (
+    output = """Script:\n--\n{0!s}\n--\nExit Code: {1:d}\n\n""".format(
         '\n'.join(script), exitCode)
 
     # Append the outputs, if present.
     if out:
-        output += """Command Output (stdout):\n--\n%s\n--\n""" % (out,)
+        output += """Command Output (stdout):\n--\n{0!s}\n--\n""".format(out)
     if err:
-        output += """Command Output (stderr):\n--\n%s\n--\n""" % (err,)
+        output += """Command Output (stderr):\n--\n{0!s}\n--\n""".format(err)
 
     return lit.Test.Result(status, output)
 

--- a/utils/lit/lit/TestingConfig.py
+++ b/utils/lit/lit/TestingConfig.py
@@ -86,7 +86,7 @@ class TestingConfig:
             try:
                 data = f.read()
             except:
-                litConfig.fatal('unable to load config file: %r' % (path,))
+                litConfig.fatal('unable to load config file: {0!r}'.format(path))
             f.close()
 
         # Execute the config script to initialize the object.
@@ -100,7 +100,7 @@ class TestingConfig:
             else:
                 exec(compile(data, path, 'exec'), cfg_globals, None)
             if litConfig.debug:
-                litConfig.note('... loaded config %r' % path)
+                litConfig.note('... loaded config {0!r}'.format(path))
         except SystemExit:
             e = sys.exc_info()[1]
             # We allow normal system exit inside a config file to just
@@ -110,7 +110,7 @@ class TestingConfig:
         except:
             import traceback
             litConfig.fatal(
-                'unable to parse config file %r, traceback: %s' % (
+                'unable to parse config file {0!r}, traceback: {1!s}'.format(
                     path, traceback.format_exc()))
 
         self.finish(litConfig)

--- a/utils/lit/lit/discovery.py
+++ b/utils/lit/lit/discovery.py
@@ -42,7 +42,7 @@ def getTestSuite(item, litConfig, cache):
 
         # We found a test suite, create a new config for it and load it.
         if litConfig.debug:
-            litConfig.note('loading suite config %r' % cfgpath)
+            litConfig.note('loading suite config {0!r}'.format(cfgpath))
 
         cfg = TestingConfig.fromdefaults(litConfig)
         cfg.load_from_path(cfgpath, litConfig)
@@ -93,7 +93,7 @@ def getLocalConfig(ts, path_in_suite, litConfig, cache):
         # file into it.
         config = copy.deepcopy(parent)
         if litConfig.debug:
-            litConfig.note('loading local config %r' % cfgpath)
+            litConfig.note('loading local config {0!r}'.format(cfgpath))
         config.load_from_path(cfgpath, litConfig)
         return config
 
@@ -110,11 +110,11 @@ def getTests(path, litConfig, testSuiteCache, localConfigCache):
     # Find the test suite for this input and its relative path.
     ts,path_in_suite = getTestSuite(path, litConfig, testSuiteCache)
     if ts is None:
-        litConfig.warning('unable to find test suite for %r' % path)
+        litConfig.warning('unable to find test suite for {0!r}'.format(path))
         return (),()
 
     if litConfig.debug:
-        litConfig.note('resolved input %r to %r::%r' % (path, ts.name,
+        litConfig.note('resolved input {0!r} to {1!r}::{2!r}'.format(path, ts.name,
                                                         path_in_suite))
 
     return ts, getTestsInSuite(ts, path_in_suite, litConfig,
@@ -187,7 +187,7 @@ def getTestsInSuite(ts, path_in_suite, litConfig,
             N += 1
             yield res
         if sub_ts and not N:
-            litConfig.warning('test suite %r contained no tests' % sub_ts.name)
+            litConfig.warning('test suite {0!r} contained no tests'.format(sub_ts.name))
 
 def find_tests_for_inputs(lit_config, inputs):
     """
@@ -221,11 +221,11 @@ def find_tests_for_inputs(lit_config, inputs):
         tests.extend(getTests(input, lit_config,
                               test_suite_cache, local_config_cache)[1])
         if prev == len(tests):
-            lit_config.warning('input %r contained no tests' % input)
+            lit_config.warning('input {0!r} contained no tests'.format(input))
 
     # If there were any errors during test discovery, exit now.
     if lit_config.numErrors:
-        sys.stderr.write('%d errors, exiting.\n' % lit_config.numErrors)
+        sys.stderr.write('{0:d} errors, exiting.\n'.format(lit_config.numErrors))
         sys.exit(2)
 
     return tests

--- a/utils/lit/lit/formats/base.py
+++ b/utils/lit/lit/formats/base.py
@@ -108,11 +108,11 @@ class OneCommandPerFileTest(TestFormat):
             return lit.Test.PASS,''
 
         # Try to include some useful information.
-        report = """Command: %s\n""" % ' '.join(["'%s'" % a
-                                                 for a in cmd])
+        report = """Command: {0!s}\n""".format(' '.join(["'{0!s}'".format(a)
+                                                 for a in cmd]))
         if self.useTempInput:
-            report += """Temporary File: %s\n""" % tmp.name
+            report += """Temporary File: {0!s}\n""".format(tmp.name)
             report += "--\n%s--\n""" % open(tmp.name).read()
-        report += """Output:\n--\n%s--""" % diags
+        report += """Output:\n--\n{0!s}--""".format(diags)
 
         return lit.Test.FAIL, report

--- a/utils/lit/lit/formats/googletest.py
+++ b/utils/lit/lit/formats/googletest.py
@@ -35,7 +35,7 @@ class GoogleTest(TestFormat):
               lines = lines.replace('\r', '')
             lines = lines.split('\n')
         except:
-            litConfig.error("unable to discover google-tests in %r" % path)
+            litConfig.error("unable to discover google-tests in {0!r}".format(path))
             raise StopIteration
 
         nested_tests = []
@@ -117,8 +117,7 @@ class GoogleTest(TestFormat):
 
         passing_test_line = '[  PASSED  ] 1 test.'
         if passing_test_line not in out:
-            msg = ('Unable to find %r in gtest output:\n\n%s%s' %
-                   (passing_test_line, out, err))
+            msg = ('Unable to find {0!r} in gtest output:\n\n{1!s}{2!s}'.format(passing_test_line, out, err))
             return lit.Test.UNRESOLVED, msg
 
         return lit.Test.PASS,''

--- a/utils/lit/lit/main.py
+++ b/utils/lit/lit/main.py
@@ -52,25 +52,25 @@ class TestingProgressDisplay(object):
 
         # Show the test result line.
         test_name = test.getFullName()
-        print('%s: %s (%d of %d)' % (test.result.code.name, test_name,
+        print('{0!s}: {1!s} ({2:d} of {3:d})'.format(test.result.code.name, test_name,
                                      self.completed, self.numTests))
 
         # Show the test failure output, if requested.
         if (test.result.code.isFailure and self.opts.showOutput) or \
            self.opts.showAllOutput:
             if test.result.code.isFailure:
-                print("%s TEST '%s' FAILED %s" % ('*'*20, test.getFullName(),
+                print("{0!s} TEST '{1!s}' FAILED {2!s}".format('*'*20, test.getFullName(),
                                                   '*'*20))
             print(test.result.output)
             print("*" * 20)
 
         # Report test metrics, if present.
         if test.result.metrics:
-            print("%s TEST '%s' RESULTS %s" % ('*'*10, test.getFullName(),
+            print("{0!s} TEST '{1!s}' RESULTS {2!s}".format('*'*10, test.getFullName(),
                                                '*'*10))
             items = sorted(test.result.metrics.items())
             for metric_name, value in items:
-                print('%s: %s ' % (metric_name, value.format()))
+                print('{0!s}: {1!s} '.format(metric_name, value.format()))
             print("*" * 10)
 
         # Ensure the output is flushed.
@@ -247,7 +247,7 @@ def main(builtinParameters = {}):
     (opts, args) = parser.parse_args()
 
     if opts.show_version:
-        print("lit %s" % (lit.__version__,))
+        print("lit {0!s}".format(lit.__version__))
         return
 
     if not args:
@@ -306,9 +306,9 @@ def main(builtinParameters = {}):
         if opts.showSuites:
             print('-- Test Suites --')
             for ts,ts_tests in suitesAndTests:
-                print('  %s - %d tests' %(ts.name, len(ts_tests)))
-                print('    Source Root: %s' % ts.source_root)
-                print('    Exec Root  : %s' % ts.exec_root)
+                print('  {0!s} - {1:d} tests'.format(ts.name, len(ts_tests)))
+                print('    Source Root: {0!s}'.format(ts.source_root))
+                print('    Exec Root  : {0!s}'.format(ts.exec_root))
 
         # Show the tests, if requested.
         if opts.showTests:
@@ -316,7 +316,7 @@ def main(builtinParameters = {}):
             for ts,ts_tests in suitesAndTests:
                 ts_tests.sort(key = lambda test: test.path_in_suite)
                 for test in ts_tests:
-                    print('  %s' % (test.getFullName(),))
+                    print('  {0!s}'.format(test.getFullName()))
 
         # Exit.
         sys.exit(0)
@@ -329,8 +329,8 @@ def main(builtinParameters = {}):
         try:
             rex = re.compile(opts.filter)
         except:
-            parser.error("invalid regular expression for --filter: %r" % (
-                    opts.filter))
+            parser.error("invalid regular expression for --filter: {0!r}".format((
+                    opts.filter)))
         run.tests = [result_test for result_test in run.tests
                      if rex.search(result_test.getFullName())]
 
@@ -366,15 +366,14 @@ def main(builtinParameters = {}):
 
         if max_procs_soft < desired_limit:
             resource.setrlimit(resource.RLIMIT_NPROC, (desired_limit, max_procs_hard))
-            litConfig.note('raised the process limit from %d to %d' % \
-                               (max_procs_soft, desired_limit))
+            litConfig.note('raised the process limit from {0:d} to {1:d}'.format(max_procs_soft, desired_limit))
     except:
         pass
 
     extra = ''
     if len(run.tests) != numTotalTests:
-        extra = ' of %d' % numTotalTests
-    header = '-- Testing: %d%s tests, %d threads --'%(len(run.tests), extra,
+        extra = ' of {0:d}'.format(numTotalTests)
+    header = '-- Testing: {0:d}{1!s} tests, {2:d} threads --'.format(len(run.tests), extra,
                                                       opts.numThreads)
 
     progressBar = None
@@ -400,7 +399,7 @@ def main(builtinParameters = {}):
 
     testing_time = time.time() - startTime
     if not opts.quiet:
-        print('Testing Time: %.2fs' % (testing_time,))
+        print('Testing Time: {0:.2f}s'.format(testing_time))
 
     # Write out the test data, if requested.
     if opts.output_path is not None:
@@ -429,9 +428,9 @@ def main(builtinParameters = {}):
         if not elts:
             continue
         print('*'*20)
-        print('%s (%d):' % (title, len(elts)))
+        print('{0!s} ({1:d}):'.format(title, len(elts)))
         for test in elts:
-            print('    %s' % test.getFullName())
+            print('    {0!s}'.format(test.getFullName()))
         sys.stdout.write('\n')
 
     if opts.timeTests and run.tests:
@@ -451,7 +450,7 @@ def main(builtinParameters = {}):
             continue
         N = len(byCode.get(code,[]))
         if N:
-            print('  %s: %d' % (name,N))
+            print('  {0!s}: {1:d}'.format(name, N))
 
     if opts.xunit_output_file:
         # Collect the tests, indexed by test suite
@@ -486,12 +485,12 @@ def main(builtinParameters = {}):
 
     # If we encountered any additional errors, exit abnormally.
     if litConfig.numErrors:
-        sys.stderr.write('\n%d error(s), exiting.\n' % litConfig.numErrors)
+        sys.stderr.write('\n{0:d} error(s), exiting.\n'.format(litConfig.numErrors))
         sys.exit(2)
 
     # Warn about warnings.
     if litConfig.numWarnings:
-        sys.stderr.write('\n%d warning(s) in tests.\n' % litConfig.numWarnings)
+        sys.stderr.write('\n{0:d} warning(s) in tests.\n'.format(litConfig.numWarnings))
 
     if hasFailures:
         sys.exit(1)

--- a/utils/lit/lit/util.py
+++ b/utils/lit/lit/util.py
@@ -133,18 +133,18 @@ def printHistogram(items, title = 'Items'):
 
     barW = 40
     hr = '-' * (barW + 34)
-    print('\nSlowest %s:' % title)
+    print('\nSlowest {0!s}:'.format(title))
     print(hr)
     for name,value in items[-20:]:
-        print('%.2fs: %s' % (value, name))
-    print('\n%s Times:' % title)
+        print('{0:.2f}s: {1!s}'.format(value, name))
+    print('\n{0!s} Times:'.format(title))
     print(hr)
     pDigits = int(math.ceil(math.log(maxValue, 10)))
     pfDigits = max(0, 3-pDigits)
     if pfDigits:
         pDigits += pfDigits + 1
     cDigits = int(math.ceil(math.log(len(items), 10)))
-    print("[%s] :: [%s] :: [%s]" % ('Range'.center((pDigits+1)*2 + 3),
+    print("[{0!s}] :: [{1!s}] :: [{2!s}]".format('Range'.center((pDigits+1)*2 + 3),
                                     'Percentage'.center(barW),
                                     'Count'.center(cDigits*2 + 1)))
     print(hr)
@@ -191,5 +191,5 @@ def usePlatformSdkOnDarwin(config, lit_config):
             res = -1
         if res == 0 and out:
             sdk_path = out
-            lit_config.note('using SDKROOT: %r' % sdk_path)
+            lit_config.note('using SDKROOT: {0!r}'.format(sdk_path))
             config.environment['SDKROOT'] = sdk_path

--- a/utils/llvm-build/llvmbuild/componentinfo.py
+++ b/utils/llvm-build/llvmbuild/componentinfo.py
@@ -32,7 +32,7 @@ class ComponentInfo(object):
 
     def __init__(self, subpath, name, dependencies, parent):
         if not subpath.startswith('/'):
-            raise ValueError("invalid subpath: %r" % subpath)
+            raise ValueError("invalid subpath: {0!r}".format(subpath))
         self.subpath = subpath
         self.name = name
         self.dependencies = list(dependencies)
@@ -104,10 +104,10 @@ class GroupComponentInfo(ComponentInfo):
 
     def get_llvmbuild_fragment(self):
         return """\
-type = %s
-name = %s
-parent = %s
-""" % (self.type_name, self.name, self.parent)
+type = {0!s}
+name = {1!s}
+parent = {2!s}
+""".format(self.type_name, self.name, self.parent)
 
 class LibraryComponentInfo(ComponentInfo):
     type_name = 'Library'
@@ -156,18 +156,18 @@ class LibraryComponentInfo(ComponentInfo):
 
     def get_llvmbuild_fragment(self):
         result = """\
-type = %s
-name = %s
-parent = %s
-""" % (self.type_name, self.name, self.parent)
+type = {0!s}
+name = {1!s}
+parent = {2!s}
+""".format(self.type_name, self.name, self.parent)
         if self.library_name is not None:
-            result += 'library_name = %s\n' % self.library_name
+            result += 'library_name = {0!s}\n'.format(self.library_name)
         if self.required_libraries:
-            result += 'required_libraries = %s\n' % ' '.join(
-                self.required_libraries)
+            result += 'required_libraries = {0!s}\n'.format(' '.join(
+                self.required_libraries))
         if self.add_to_library_groups:
-            result += 'add_to_library_groups = %s\n' % ' '.join(
-                self.add_to_library_groups)
+            result += 'add_to_library_groups = {0!s}\n'.format(' '.join(
+                self.add_to_library_groups))
         if not self.installed:
             result += 'installed = 0\n'
         return result
@@ -190,7 +190,7 @@ parent = %s
         if basename in ('gtest', 'gtest_main'):
             return basename
 
-        return 'LLVM%s' % basename
+        return 'LLVM{0!s}'.format(basename)
 
     def get_llvmconfig_component_name(self):
         return self.get_library_name().lower()
@@ -242,16 +242,16 @@ class LibraryGroupComponentInfo(ComponentInfo):
 
     def get_llvmbuild_fragment(self):
         result = """\
-type = %s
-name = %s
-parent = %s
-""" % (self.type_name, self.name, self.parent)
+type = {0!s}
+name = {1!s}
+parent = {2!s}
+""".format(self.type_name, self.name, self.parent)
         if self.required_libraries and not self._is_special_group:
-            result += 'required_libraries = %s\n' % ' '.join(
-                self.required_libraries)
+            result += 'required_libraries = {0!s}\n'.format(' '.join(
+                self.required_libraries))
         if self.add_to_library_groups:
-            result += 'add_to_library_groups = %s\n' % ' '.join(
-                self.add_to_library_groups)
+            result += 'add_to_library_groups = {0!s}\n'.format(' '.join(
+                self.add_to_library_groups))
         return result
 
     def get_llvmconfig_component_name(self):
@@ -315,20 +315,20 @@ class TargetGroupComponentInfo(ComponentInfo):
 
     def get_llvmbuild_fragment(self):
         result = """\
-type = %s
-name = %s
-parent = %s
-""" % (self.type_name, self.name, self.parent)
+type = {0!s}
+name = {1!s}
+parent = {2!s}
+""".format(self.type_name, self.name, self.parent)
         if self.required_libraries:
-            result += 'required_libraries = %s\n' % ' '.join(
-                self.required_libraries)
+            result += 'required_libraries = {0!s}\n'.format(' '.join(
+                self.required_libraries))
         if self.add_to_library_groups:
-            result += 'add_to_library_groups = %s\n' % ' '.join(
-                self.add_to_library_groups)
+            result += 'add_to_library_groups = {0!s}\n'.format(' '.join(
+                self.add_to_library_groups))
         for bool_key in ('has_asmparser', 'has_asmprinter', 'has_disassembler',
                          'has_jit'):
             if getattr(self, bool_key):
-                result += '%s = 1\n' % (bool_key,)
+                result += '{0!s} = 1\n'.format(bool_key)
         return result
 
     def get_llvmconfig_component_name(self):
@@ -359,11 +359,11 @@ class ToolComponentInfo(ComponentInfo):
 
     def get_llvmbuild_fragment(self):
         return """\
-type = %s
-name = %s
-parent = %s
-required_libraries = %s
-""" % (self.type_name, self.name, self.parent,
+type = {0!s}
+name = {1!s}
+parent = {2!s}
+required_libraries = {3!s}
+""".format(self.type_name, self.name, self.parent,
        ' '.join(self.required_libraries))
 
 class BuildToolComponentInfo(ToolComponentInfo):
@@ -392,13 +392,13 @@ class IniFormatParser(dict):
         if not value:
             return None
         if len(value) > 1:
-            raise ParseError("multiple values for scalar key: %r" % key)
+            raise ParseError("multiple values for scalar key: {0!r}".format(key))
         return value[0]
 
     def get_string(self, key):
         value = self.get_optional_string(key)
         if not value:
-            raise ParseError("missing value for required string: %r" % key)
+            raise ParseError("missing value for required string: {0!r}".format(key))
         return value
 
     def get_optional_bool(self, key, default = None):
@@ -406,14 +406,14 @@ class IniFormatParser(dict):
         if not value:
             return default
         if value not in ('0', '1'):
-            raise ParseError("invalid value(%r) for boolean property: %r" % (
+            raise ParseError("invalid value({0!r}) for boolean property: {1!r}".format(
                     value, key))
         return bool(int(value))
 
     def get_bool(self, key):
         value = self.get_optional_bool(key)
         if value is None:
-            raise ParseError("missing value for required boolean: %r" % key)
+            raise ParseError("missing value for required boolean: {0!r}".format(key))
         return value
 
 _component_type_map = dict(
@@ -442,33 +442,33 @@ def _read_components_from_parser(parser, path, subpath):
     for section in parser.sections():
         if not section.startswith('component'):
             # We don't expect arbitrary sections currently, warn the user.
-            warning("ignoring unknown section %r in %r" % (section, path))
+            warning("ignoring unknown section {0!r} in {1!r}".format(section, path))
             continue
 
         # Determine the type of the component to instantiate.
         if not parser.has_option(section, 'type'):
-            fatal("invalid component %r in %r: %s" % (
+            fatal("invalid component {0!r} in {1!r}: {2!s}".format(
                     section, path, "no component type"))
 
         type_name = parser.get(section, 'type')
         type_class = _component_type_map.get(type_name)
         if type_class is None:
-            fatal("invalid component %r in %r: %s" % (
-                    section, path, "invalid component type: %r" % type_name))
+            fatal("invalid component {0!r} in {1!r}: {2!s}".format(
+                    section, path, "invalid component type: {0!r}".format(type_name)))
 
         # Instantiate the component based on the remaining values.
         try:
             info = type_class.parse(subpath,
                                     IniFormatParser(parser.items(section)))
         except TypeError:
-            print >>sys.stderr, "error: invalid component %r in %r: %s" % (
-                section, path, "unable to instantiate: %r" % type_name)
+            print >>sys.stderr, "error: invalid component {0!r} in {1!r}: {2!s}".format(
+                section, path, "unable to instantiate: {0!r}".format(type_name))
             import traceback
             traceback.print_exc()
             raise SystemExit(1)
         except ParseError:
             e = sys.exc_info()[1]
-            fatal("unable to load component %r in %r: %s" % (
+            fatal("unable to load component {0!r} in {1!r}: {2!s}".format(
                     section, path, e.message))
 
         info._source_path = path

--- a/utils/llvm-build/llvmbuild/main.py
+++ b/utils/llvm-build/llvmbuild/main.py
@@ -70,7 +70,7 @@ class LLVMProjectInfo(object):
             llvmbuild_path = os.path.join(llvmbuild_source_root + subpath,
                                           'LLVMBuild.txt')
             if not os.path.exists(llvmbuild_path):
-                fatal("missing LLVMBuild.txt file at: %r" % (llvmbuild_path,))
+                fatal("missing LLVMBuild.txt file at: {0!r}".format(llvmbuild_path))
 
             # Parse the components from it.
             common,info_iter = componentinfo.load_from_path(llvmbuild_path,
@@ -118,7 +118,7 @@ class LLVMProjectInfo(object):
             existing = self.component_info_map.get(ci.name)
             if existing is not None:
                 # We found a duplicate component name, report it and error out.
-                fatal("found duplicate component %r (at %r and %r)" % (
+                fatal("found duplicate component {0!r} (at {1!r} and {2!r})".format(
                         ci.name, ci.subpath, existing.subpath))
             self.component_info_map[ci.name] = ci
 
@@ -140,9 +140,9 @@ class LLVMProjectInfo(object):
             if ci in current_set:
                 # We found a cycle, report it and error out.
                 cycle_description = ' -> '.join(
-                    '%r (%s)' % (ci.name, relation)
+                    '{0!r} ({1!s})'.format(ci.name, relation)
                     for relation,ci in current_stack)
-                fatal("found cycle to %r after following: %s -> %s" % (
+                fatal("found cycle to {0!r} after following: {1!s} -> {2!s}".format(
                         ci.name, cycle_description, ci.name))
 
             # If we have already visited this item, we are done.
@@ -156,7 +156,7 @@ class LLVMProjectInfo(object):
             if ci.parent is not None:
                 parent = self.component_info_map.get(ci.parent)
                 if parent is None:
-                    fatal("component %r has invalid reference %r (via %r)" % (
+                    fatal("component {0!r} has invalid reference {1!r} (via {2!r})".format(
                             ci.name, ci.parent, 'parent'))
                 ci.set_parent_instance(parent)
 
@@ -164,7 +164,7 @@ class LLVMProjectInfo(object):
                 # Validate that the reference is ok.
                 referent = self.component_info_map.get(referent_name)
                 if referent is None:
-                    fatal("component %r has invalid reference %r (via %r)" % (
+                    fatal("component {0!r} has invalid reference {1!r} (via {2!r})".format(
                             ci.name, referent_name, relation))
 
                 # Visit the reference.
@@ -195,7 +195,7 @@ class LLVMProjectInfo(object):
 
     def print_tree(self):
         def visit(node, depth = 0):
-            print('%s%-40s (%s)' % ('  '*depth, node.name, node.type_name))
+            print('{0!s}{1:<40!s} ({2!s})'.format('  '*depth, node.name, node.type_name))
             for c in node.children:
                 visit(c, depth + 1)
         visit(self.component_info_map['$ROOT'])
@@ -236,8 +236,8 @@ class LLVMProjectInfo(object):
             subdirectories = subpath_subdirs.get(subpath)
             if subdirectories:
                 fragment = """\
-subdirectories = %s
-""" % (" ".join(sorted(subdirectories)),)
+subdirectories = {0!s}
+""".format(" ".join(sorted(subdirectories)))
                 fragments.append(("common", fragment))
 
             # Add the component fragments.
@@ -247,7 +247,7 @@ subdirectories = %s
                 if fragment is None:
                     continue
 
-                name = "component_%d" % (len(fragments) - num_common_fragments)
+                name = "component_{0:d}".format((len(fragments) - num_common_fragments))
                 fragments.append((name, fragment))
 
             if not fragments:
@@ -285,7 +285,7 @@ subdirectories = %s
             header_pad = '-' * (80 - len(header_fmt % (header_name, '')))
             header_string = header_fmt % (header_name, header_pad)
             f.write("""\
-%s
+{0!s}
 ;
 ;                     The LLVM Compiler Infrastructure
 ;
@@ -302,14 +302,14 @@ subdirectories = %s
 ;
 ;===------------------------------------------------------------------------===;
 
-""" % header_string)
+""".format(header_string))
 
             # Write out each fragment.each component fragment.
             for name,fragment in fragments:
                 comment = comments_map.get(name)
                 if comment is not None:
                     f.write(comment)
-                f.write("[%s]\n" % name)
+                f.write("[{0!s}]\n".format(name))
                 f.write(fragment)
                 if fragment is not fragments[-1][1]:
                     f.write('\n')
@@ -406,21 +406,21 @@ subdirectories = %s
         f.write('\n')
         f.write('\
   /// The list of libraries required when linking this component.\n')
-        f.write('  const char *RequiredLibraries[%d];\n' % (
-            max_required_libraries))
-        f.write('} AvailableComponents[%d] = {\n' % len(entries))
+        f.write('  const char *RequiredLibraries[{0:d}];\n'.format((
+            max_required_libraries)))
+        f.write('}} AvailableComponents[{0:d}] = {{\n'.format(len(entries)))
         for name,library_name,required_names,is_installed in entries:
             if library_name is None:
                 library_name_as_cstr = 'nullptr'
             else:
-                library_name_as_cstr = '"lib%s.a"' % library_name
+                library_name_as_cstr = '"lib{0!s}.a"'.format(library_name)
             if is_installed:
                 is_installed_as_cstr = 'true'
             else:
                 is_installed_as_cstr = 'false'
-            f.write('  { "%s", %s, %s, { %s } },\n' % (
+            f.write('  {{ "{0!s}", {1!s}, {2!s}, {{ {3!s} }} }},\n'.format(
                 name, library_name_as_cstr, is_installed_as_cstr,
-                ', '.join('"%s"' % dep
+                ', '.join('"{0!s}"'.format(dep)
                           for dep in required_names)))
         f.write('};\n')
         f.close()
@@ -555,7 +555,7 @@ subdirectories = %s
         header_pad = '-' * (80 - len(header_fmt % (header_name, '')))
         header_string = header_fmt % (header_name, header_pad)
         f.write("""\
-%s
+{0!s}
 #
 #                     The LLVM Compiler Infrastructure
 #
@@ -571,7 +571,7 @@ subdirectories = %s
 #
 #===------------------------------------------------------------------------===#
 
-""" % header_string)
+""".format(header_string))
 
         # Write the dependency information in the best way we can.
         f.write("""
@@ -588,9 +588,9 @@ subdirectories = %s
 """)
         for dep in dependencies:
             f.write("""\
-configure_file(\"%s\"
-               ${CMAKE_CURRENT_BINARY_DIR}/DummyConfigureOutput)\n""" % (
-                cmake_quote_path(dep),))
+configure_file(\"{0!s}\"
+               ${{CMAKE_CURRENT_BINARY_DIR}}/DummyConfigureOutput)\n""".format(
+                cmake_quote_path(dep)))
 
         # Write the properties we use to encode the required library dependency
         # information in a form CMake can easily use directly.
@@ -603,7 +603,7 @@ configure_file(\"%s\"
         self.foreach_cmake_library(
             lambda ci:
               f.write("""\
-set_property(GLOBAL PROPERTY LLVMBUILD_LIB_DEPS_%s %s)\n""" % (
+set_property(GLOBAL PROPERTY LLVMBUILD_LIB_DEPS_{0!s} {1!s})\n""".format(
                 ci.get_prefixed_library_name(), " ".join(sorted(
                      dep.get_prefixed_library_name()
                      for dep in self.get_required_libraries_for_component(ci)))))
@@ -639,7 +639,7 @@ set_property(GLOBAL PROPERTY LLVMBUILD_LIB_DEPS_%s %s)\n""" % (
         self.foreach_cmake_library(
             lambda ci:
               f.write("""\
-set_property(TARGET %s PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES %s)\n""" % (
+set_property(TARGET {0!s} PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES {1!s})\n""".format(
                 ci.get_prefixed_library_name(), " ".join(sorted(
                      dep.get_prefixed_library_name()
                      for dep in self.get_required_libraries_for_component(ci)))))
@@ -674,7 +674,7 @@ set_property(TARGET %s PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES %s)\n""" % (
         header_pad = '-' * (80 - len(header_fmt % (header_name, '')))
         header_string = header_fmt % (header_name, header_pad)
         f.write("""\
-%s
+{0!s}
 #
 #                     The LLVM Compiler Infrastructure
 #
@@ -690,7 +690,7 @@ set_property(TARGET %s PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES %s)\n""" % (
 #
 #===------------------------------------------------------------------------===#
 
-""" % header_string)
+""".format(header_string))
 
         # Write the dependencies for the fragment.
         #
@@ -702,9 +702,9 @@ set_property(TARGET %s PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES %s)\n""" % (
 """)
         f.write('ifeq ($(LLVMBUILD_INCLUDE_DEPENDENCIES),1)\n')
         f.write("# The dependencies for this Makefile fragment itself.\n")
-        f.write("%s: \\\n" % (mk_quote_string_for_target(output_path),))
+        f.write("{0!s}: \\\n".format(mk_quote_string_for_target(output_path)))
         for dep in dependencies:
-            f.write("\t%s \\\n" % (dep,))
+            f.write("\t{0!s} \\\n".format(dep))
         f.write('\n')
 
         # Generate dummy rules for each of the dependencies, so that things
@@ -714,7 +714,7 @@ set_property(TARGET %s PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES %s)\n""" % (
 # removed.
 """)
         for dep in dependencies:
-            f.write("%s:\n" % (mk_quote_string_for_target(dep),))
+            f.write("{0!s}:\n".format(mk_quote_string_for_target(dep)))
         f.write('endif\n')
 
         f.write("""
@@ -723,7 +723,7 @@ set_property(TARGET %s PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES %s)\n""" % (
 LLVM_LIBS_TO_EXPORT :=""")
         self.foreach_cmake_library(
             lambda ci:
-                f.write(' \\\n  %s' % ci.get_prefixed_library_name())
+                f.write(' \\\n  {0!s}'.format(ci.get_prefixed_library_name()))
             ,
             enabled_optional_components,
             skip_disabled = True,
@@ -760,11 +760,11 @@ def add_magic_target_components(parser, project, opts):
     else:
         native_target = available_targets.get(native_target_name)
         if native_target is None:
-            parser.error("invalid native target: %r (not in project)" % (
-                    opts.native_target,))
+            parser.error("invalid native target: {0!r} (not in project)".format(
+                    opts.native_target))
         if native_target.type_name != 'TargetGroup':
-            parser.error("invalid native target: %r (not a target)" % (
-                    opts.native_target,))
+            parser.error("invalid native target: {0!r} (not a target)".format(
+                    opts.native_target))
 
     # Find the list of targets to enable.
     if opts.enable_targets is None:
@@ -782,11 +782,11 @@ def add_magic_target_components(parser, project, opts):
         for name in enable_target_names:
             target = available_targets.get(name)
             if target is None:
-                parser.error("invalid target to enable: %r (not in project)" % (
-                        name,))
+                parser.error("invalid target to enable: {0!r} (not in project)".format(
+                        name))
             if target.type_name != 'TargetGroup':
-                parser.error("invalid target to enable: %r (not a target)" % (
-                        name,))
+                parser.error("invalid target to enable: {0!r} (not a target)".format(
+                        name))
             enable_targets.append(target)
 
     # Find the special library groups we are going to populate. We enforce that
@@ -796,18 +796,18 @@ def add_magic_target_components(parser, project, opts):
     def find_special_group(name):
         info = info_map.get(name)
         if info is None:
-            fatal("expected project to contain special %r component" % (
-                    name,))
+            fatal("expected project to contain special {0!r} component".format(
+                    name))
 
         if info.type_name != 'LibraryGroup':
-            fatal("special component %r should be a LibraryGroup" % (
-                    name,))
+            fatal("special component {0!r} should be a LibraryGroup".format(
+                    name))
 
         if info.required_libraries:
-            fatal("special component %r must have empty %r list" % (
+            fatal("special component {0!r} must have empty {1!r} list".format(
                     name, 'required_libraries'))
         if info.add_to_library_groups:
-            fatal("special component %r must have empty %r list" % (
+            fatal("special component {0!r} must have empty {1!r} list".format(
                     name, 'add_to_library_groups'))
 
         info._is_special_group = True
@@ -830,7 +830,7 @@ def add_magic_target_components(parser, project, opts):
     if native_target and native_target.enabled:
         native_group.required_libraries.append(native_target.name)
         native_codegen_group.required_libraries.append(
-            '%sCodeGen' % native_target.name)
+            '{0!s}CodeGen'.format(native_target.name))
 
     # If we have a native target with a JIT, use that for the engine. Otherwise,
     # use the interpreter.
@@ -916,7 +916,7 @@ given by --build-root) at the same SUBPATH""",
     if source_root:
         if not os.path.exists(os.path.join(source_root, 'lib', 'IR',
                                            'Function.cpp')):
-            parser.error('invalid LLVM source root: %r' % source_root)
+            parser.error('invalid LLVM source root: {0!r}'.format(source_root))
     else:
         llvmbuild_path = os.path.dirname(__file__)
         llvm_build_path = os.path.dirname(llvmbuild_path)
@@ -976,18 +976,18 @@ given by --build-root) at the same SUBPATH""",
                              if ci.type_name == 'TargetGroup']
         substitutions = [
             ("@LLVM_ENUM_TARGETS@",
-             ' '.join('LLVM_TARGET(%s)' % ci.name
+             ' '.join('LLVM_TARGET({0!s})'.format(ci.name)
                       for ci in available_targets)),
             ("@LLVM_ENUM_ASM_PRINTERS@",
-             ' '.join('LLVM_ASM_PRINTER(%s)' % ci.name
+             ' '.join('LLVM_ASM_PRINTER({0!s})'.format(ci.name)
                       for ci in available_targets
                       if ci.has_asmprinter)),
             ("@LLVM_ENUM_ASM_PARSERS@",
-             ' '.join('LLVM_ASM_PARSER(%s)' % ci.name
+             ' '.join('LLVM_ASM_PARSER({0!s})'.format(ci.name)
                       for ci in available_targets
                       if ci.has_asmparser)),
             ("@LLVM_ENUM_DISASSEMBLERS@",
-             ' '.join('LLVM_DISASSEMBLER(%s)' % ci.name
+             ' '.join('LLVM_DISASSEMBLER({0!s})'.format(ci.name)
                       for ci in available_targets
                       if ci.has_disassembler))]
 
@@ -997,7 +997,7 @@ given by --build-root) at the same SUBPATH""",
             outpath = os.path.join(opts.build_root, subpath)
             result = configutil.configure_file(inpath, outpath, substitutions)
             if not result:
-                note("configured file %r hasn't changed" % outpath)
+                note("configured file {0!r} hasn't changed".format(outpath))
 
 if __name__=='__main__':
     main()

--- a/utils/llvm-build/llvmbuild/util.py
+++ b/utils/llvm-build/llvmbuild/util.py
@@ -3,7 +3,7 @@ import sys
 
 def _write_message(kind, message):
     program = os.path.basename(sys.argv[0])
-    sys.stderr.write('%s: %s: %s\n' % (program, kind, message))
+    sys.stderr.write('{0!s}: {1!s}: {2!s}\n'.format(program, kind, message))
 
 note = lambda message: _write_message('note', message)
 warning = lambda message: _write_message('warning', message)

--- a/utils/update_llc_test_checks.py
+++ b/utils/update_llc_test_checks.py
@@ -76,14 +76,14 @@ def main():
 
   for test in args.tests:
     if args.verbose:
-      print >>sys.stderr, 'Scanning for RUN lines in test file: %s' % (test,)
+      print >>sys.stderr, 'Scanning for RUN lines in test file: {0!s}'.format(test)
     with open(test) as f:
       test_lines = [l.rstrip() for l in f]
 
     run_lines = [m.group(1)
                  for m in [run_line_re.match(l) for l in test_lines] if m]
     if args.verbose:
-      print >>sys.stderr, 'Found %d RUN lines:' % (len(run_lines),)
+      print >>sys.stderr, 'Found {0:d} RUN lines:'.format(len(run_lines))
       for l in run_lines:
         print >>sys.stderr, '  RUN: ' + l
 
@@ -147,7 +147,7 @@ def main():
     is_in_function_start = False
     prefix_set = set([prefix for prefixes, _ in checks for prefix in prefixes])
     if args.verbose:
-      print >>sys.stderr, 'Rewriting FileCheck prefixes: %s' % (prefix_set,)
+      print >>sys.stderr, 'Rewriting FileCheck prefixes: {0!s}'.format(prefix_set)
     fixed_lines = []
     for l in test_lines:
       if is_in_function_start:
@@ -168,11 +168,11 @@ def main():
             if len(printed_prefixes) != 0:
               fixed_lines.append(';')
             printed_prefixes.append(prefix)
-            fixed_lines.append('; %s-LABEL: %s:' % (prefix, name))
+            fixed_lines.append('; {0!s}-LABEL: {1!s}:'.format(prefix, name))
             asm_lines = asm[prefix][name].splitlines()
-            fixed_lines.append('; %s:       %s' % (prefix, asm_lines[0]))
+            fixed_lines.append('; {0!s}:       {1!s}'.format(prefix, asm_lines[0]))
             for asm_line in asm_lines[1:]:
-              fixed_lines.append('; %s-NEXT:  %s' % (prefix, asm_line))
+              fixed_lines.append('; {0!s}-NEXT:  {1!s}'.format(prefix, asm_line))
             break
         is_in_function_start = False
 
@@ -203,7 +203,7 @@ def main():
       is_in_function = is_in_function_start = True
 
     if args.verbose:
-      print>>sys.stderr, 'Writing %d fixed lines to %s...' % (
+      print>>sys.stderr, 'Writing {0:d} fixed lines to {1!s}...'.format(
           len(fixed_lines), test)
     with open(test, 'w') as f:
       f.writelines([l + '\n' for l in fixed_lines])


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:swift-llvm?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:swift-llvm?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
